### PR TITLE
client: Use a map for the underlying store in messageHandlers

### DIFF
--- a/client/message_handlers.go
+++ b/client/message_handlers.go
@@ -17,8 +17,7 @@ type messageHandler struct {
 }
 
 type messageHandlers struct {
-	handlers       sync.Map
-	defaultHandler MessageHandlerFunc
+	handlers sync.Map
 }
 
 func (mhs *messageHandlers) store(route []string, callback MessageHandlerFunc) {
@@ -52,11 +51,6 @@ func (mhs *messageHandlers) handle(client *Client, topic string, msg *msgs.Publi
 	if callback != nil {
 		go callback(client, topic, msg)
 		return
-	} else {
-		if mhs.defaultHandler != nil {
-			go mhs.defaultHandler(client, topic, msg)
-			return
-		}
 	}
 }
 

--- a/client/message_handlers.go
+++ b/client/message_handlers.go
@@ -28,6 +28,10 @@ func (mhs *messageHandlers) store(route []string, callback MessageHandlerFunc) {
 	})
 }
 
+func (mhs *messageHandlers) delete(route []string) {
+	mhs.handlers.Delete(join(route))
+}
+
 func (mhs *messageHandlers) handle(client *Client, topic string, msg *msgs.PublishMessage) {
 	var callback MessageHandlerFunc
 	route := split(topic)

--- a/client/message_handlers.go
+++ b/client/message_handlers.go
@@ -21,7 +21,7 @@ type messageHandlers struct {
 	defaultHandler MessageHandlerFunc
 }
 
-func (mhs *messageHandlers) add(route []string, callback MessageHandlerFunc) {
+func (mhs *messageHandlers) store(route []string, callback MessageHandlerFunc) {
 	mhs.handlers.Store(join(route), &messageHandler{
 		route:    route,
 		callback: callback,

--- a/client/subscribe_transaction.go
+++ b/client/subscribe_transaction.go
@@ -82,7 +82,7 @@ func (t *subscribeTransaction) Suback(suback *msgs.SubackMessage) {
 		return
 	}
 
-	t.client.messageHandlers.add(
+	t.client.messageHandlers.store(
 		strings.Split(topicName, "/"),
 		t.callback,
 	)


### PR DESCRIPTION
According to the MQTT specification:

> If a Server receives a SUBSCRIBE Packet containing a Topic Filter that is identical to an existing Subscription’s Topic Filter then it MUST completely replace that existing Subscription with a new Subscription.

This certainly wasn't the case with a slice based store, where new
handlers were appended to the end of the slice. Furthermore, the
`handle` method executed only a callback in the first matched route,
ignoring any later updates made with SUBSCRIBE.