### PR TITLE
Add workflow file to build and push the Docker image

### DIFF
--- a/.github/workflows/bisquitt-docker.yaml
+++ b/.github/workflows/bisquitt-docker.yaml
@@ -1,0 +1,28 @@
+name: bisquitt docker
+
+on:
+  push:
+    tags: [ "*" ]
+
+jobs:
+  build-and-push-image:
+    name: Build and push a Docker image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: "go/src/github.com/energomonitor/bisquitt"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build image
+        run: "make docker/build"
+        working-directory: "go/src/github.com/energomonitor/bisquitt"
+
+      - name: Push image
+        run: "make docker/push"
+        working-directory: "go/src/github.com/energomonitor/bisquitt"

--- a/.github/workflows/bisquitt-tests.yaml
+++ b/.github/workflows/bisquitt-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go_version: ["1.16.15", "1.17.8", "1.18.1"]
+        go_version: [ "1.16.15", "1.17.8", "1.18.1" ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
     name: Code format - go ${{ matrix.go_version }}
     strategy:
       matrix:
-        go_version: ["1.18.1"]
+        go_version: [ "1.18.1" ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder_version: ["1.16.15-bullseye", "1.17.8-bullseye", "1.18.1-bullseye"]
+        builder_version: [ "1.16.15-bullseye", "1.17.8-bullseye", "1.18.1-bullseye" ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds a new workflow file to build and push bisquitt Docker image. The workflow runs whenever a tag is pushed. For it to work, we must add two secrets to our repository:

* `DOCKERHUB_USERNAME`
* `DOCKERHUB_TOKEN`

I'm making use of the existing Makefile targets to build and push the image. To get the version information, the workflow relies on `version.txt` and disregards the tag name. This may lead to some weird outcomes, such as accidentally updating an old tagged image if someone pushes a new tag which hasn't had `version.txt` updated. I'm not sure how I feel about this.

Closes #21.