### PR TITLE
Universal transaction store

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -315,7 +315,7 @@ func (c *Client) Connect() error {
 
 	for i := uint(0); i < c.cfg.RetryCount+1; i++ {
 		transaction := newConnectTransaction(c.groupCtx, c)
-		c.transactions.StoreByType(pkts.CONNECT, transaction)
+		c.transactions.StoreByType(uint8(pkts.CONNECT), transaction)
 
 		if err := c.send(connect); err != nil {
 			return err
@@ -495,7 +495,7 @@ func (c *Client) PublishPredefined(topicID uint16, qos uint8, retain bool, paylo
 func (c *Client) Ping() error {
 	transaction := newPingTransaction(c)
 	ping := pkts.NewPingreq(nil)
-	c.transactions.StoreByType(pkts.PINGREQ, transaction)
+	c.transactions.StoreByType(uint8(pkts.PINGREQ), transaction)
 	transaction.Proceed(nil, ping)
 	if err := c.send(ping); err != nil {
 		transaction.Fail(err)
@@ -511,7 +511,7 @@ func (c *Client) Ping() error {
 // Sleep informs the MQTT-SN gateway that the client is going to sleep.
 func (c *Client) Sleep(duration time.Duration) error {
 	transaction := newSleepTransaction(c, duration)
-	c.transactions.StoreByType(pkts.DISCONNECT, transaction)
+	c.transactions.StoreByType(uint8(pkts.DISCONNECT), transaction)
 	if err := transaction.Sleep(); err != nil {
 		return err
 	}
@@ -536,7 +536,7 @@ func (c *Client) Disconnect() error {
 	}
 	transaction := newDisconnectTransaction(c)
 	disconnect := pkts.NewDisconnect(0)
-	c.transactions.StoreByType(pkts.DISCONNECT, transaction)
+	c.transactions.StoreByType(uint8(pkts.DISCONNECT), transaction)
 	transaction.Proceed(awaitingDisconnect, disconnect)
 	if err := c.send(disconnect); err != nil {
 		transaction.Fail(err)

--- a/client/connect_transaction.go
+++ b/client/connect_transaction.go
@@ -21,7 +21,7 @@ func newConnectTransaction(ctx context.Context, client *Client) *connectTransact
 		TimedTransaction: transactions.NewTimedTransaction(
 			ctx, client.cfg.ConnectTimeout,
 			func() {
-				client.transactions.DeleteByType(pkts.CONNECT)
+				client.transactions.DeleteByType(uint8(pkts.CONNECT))
 				tLog.Debug("Deleted.")
 			},
 		),

--- a/client/disconnect_transaction.go
+++ b/client/disconnect_transaction.go
@@ -21,7 +21,7 @@ func newDisconnectTransaction(client *Client) *disconnectTransaction {
 					return client.send(lastMsg.(pkts.Packet))
 				},
 				func() {
-					client.transactions.DeleteByType(pkts.DISCONNECT)
+					client.transactions.DeleteByType(uint8(pkts.DISCONNECT))
 					tLog.Debug("Deleted.")
 				},
 			),

--- a/client/net.go
+++ b/client/net.go
@@ -121,7 +121,7 @@ func (c *Client) topicForPublish(pkt *pkts.Publish) (string, error) {
 func (c *Client) handlePacket(pktx pkts.Packet) error {
 	switch pkt := pktx.(type) {
 	case *pkts.Connack:
-		transactionx, _ := c.transactions.GetByType(pkts.CONNECT)
+		transactionx, _ := c.transactions.GetByType(uint8(pkts.CONNECT))
 		transaction, ok := transactionx.(*connectTransaction)
 		if !ok {
 			c.log.Error("Unexpected transaction type %T for packet: %v", transactionx, pkt)
@@ -260,7 +260,7 @@ func (c *Client) handlePacket(pktx pkts.Packet) error {
 		return nil
 
 	case *pkts.Disconnect:
-		transactionx, ok := c.transactions.GetByType(pkts.DISCONNECT)
+		transactionx, ok := c.transactions.GetByType(uint8(pkts.DISCONNECT))
 		if !ok {
 			// Unsolicited DISCONNECT from broker.
 			c.setState(util.StateDisconnected)
@@ -287,10 +287,10 @@ func (c *Client) handlePacket(pktx pkts.Packet) error {
 		return c.send(willMsg)
 
 	case *pkts.Pingresp:
-		transactionx, ok := c.transactions.GetByType(pkts.PINGREQ)
+		transactionx, ok := c.transactions.GetByType(uint8(pkts.PINGREQ))
 		if !ok {
 			// Sleep transaction.
-			transactionx, _ = c.transactions.GetByType(pkts.DISCONNECT)
+			transactionx, _ = c.transactions.GetByType(uint8(pkts.DISCONNECT))
 		}
 		transaction, ok := transactionx.(transactionWithPingresp)
 		if !ok {

--- a/client/ping_transaction.go
+++ b/client/ping_transaction.go
@@ -21,7 +21,7 @@ func newPingTransaction(client *Client) *pingTransaction {
 					return client.send(lastMsg.(pkts.Packet))
 				},
 				func() {
-					client.transactions.DeleteByType(pkts.PINGREQ)
+					client.transactions.DeleteByType(uint8(pkts.PINGREQ))
 					tLog.Debug("Deleted.")
 				},
 			),

--- a/client/sleep_transaction.go
+++ b/client/sleep_transaction.go
@@ -37,7 +37,7 @@ func newSleepTransaction(client *Client, sleepDuration time.Duration) *sleepTran
 	t.TransactionBase = transactions.NewTransactionBase(
 		func() {
 			t.stopTimer()
-			client.transactions.DeleteByType(pkts.DISCONNECT)
+			client.transactions.DeleteByType(uint8(pkts.DISCONNECT))
 			tLog.Debug("Deleted.")
 		})
 

--- a/gateway/connect_transaction.go
+++ b/gateway/connect_transaction.go
@@ -36,7 +36,7 @@ func newConnectTransaction(ctx context.Context, h *handler, authEnabled bool, mq
 		TimedTransaction: transactions.NewTimedTransaction(
 			ctx, connectTransactionTimeout,
 			func() {
-				h.transactions.DeleteByType(snPkts.CONNECT)
+				h.transactions.DeleteByType(uint8(snPkts.CONNECT))
 				tLog.Debug("Deleted.")
 			},
 		),

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -58,7 +58,7 @@ func TestRepeatedConnect(t *testing.T) {
 	assert.Equal(byte(4), mqttConnect.ProtocolVersion)
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
-	transaction1, ok := stp.handler.transactions.GetByType(snPkts.CONNECT)
+	transaction1, ok := stp.handler.transactions.GetByType(uint8(snPkts.CONNECT))
 	assert.True(ok)
 
 	// Test transaction1 will be cancelled
@@ -86,7 +86,7 @@ func TestRepeatedConnect(t *testing.T) {
 	assert.Equal(byte(4), mqttConnect.ProtocolVersion)
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
-	transaction2, ok := stp.handler.transactions.GetByType(snPkts.CONNECT)
+	transaction2, ok := stp.handler.transactions.GetByType(uint8(snPkts.CONNECT))
 	assert.True(ok)
 	assert.NotEqual(transaction1, transaction2)
 

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -366,7 +366,7 @@ func (h *handler) handleMqtt(ctx context.Context, pkt mqttPackets.ControlPacket)
 
 	// Client CONNECT transaction.
 	case *mqttPackets.ConnackPacket:
-		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
+		transactionx, _ := h.transactions.GetByType(uint8(snPkts.CONNECT))
 		transaction, ok := transactionx.(*connectTransaction)
 		if !ok {
 			h.log.Error("Unexpected transaction type %T for packet: %v", transactionx, mqMsg)
@@ -568,11 +568,11 @@ func (h *handler) handleConnect(ctx context.Context, snConnect *snPkts.Connect) 
 	}
 
 	// Cancel previous transaction, if any.
-	if oldTransaction, ok := h.transactions.GetByType(snPkts.CONNECT); ok {
+	if oldTransaction, ok := h.transactions.GetByType(uint8(snPkts.CONNECT)); ok {
 		oldTransaction.Fail(Cancelled)
 	}
 	transaction := newConnectTransaction(ctx, h, h.cfg.AuthEnabled, mqConnect)
-	h.transactions.StoreByType(snPkts.CONNECT, transaction)
+	h.transactions.StoreByType(uint8(snPkts.CONNECT), transaction)
 	return transaction.Start(ctx)
 }
 
@@ -708,7 +708,7 @@ func (h *handler) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 
 	// Client CONNECT transaction.
 	case *snPkts.Auth:
-		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
+		transactionx, _ := h.transactions.GetByType(uint8(snPkts.CONNECT))
 		if transaction, ok := transactionx.(*connectTransaction); ok {
 			return transaction.Auth(snMsg)
 		}
@@ -717,7 +717,7 @@ func (h *handler) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 
 	// Client CONNECT transaction.
 	case *snPkts.WillTopic:
-		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
+		transactionx, _ := h.transactions.GetByType(uint8(snPkts.CONNECT))
 		if transaction, ok := transactionx.(*connectTransaction); ok {
 			return transaction.WillTopic(snMsg)
 		}
@@ -726,7 +726,7 @@ func (h *handler) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 
 	// Client CONNECT transaction.
 	case *snPkts.WillMsg:
-		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
+		transactionx, _ := h.transactions.GetByType(uint8(snPkts.CONNECT))
 		if transaction, ok := transactionx.(*connectTransaction); ok {
 			return transaction.WillMsg(snMsg)
 		}

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -736,7 +736,7 @@ func (h *handler) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 	// Client REGISTER transaction.
 	case *snPkts.Register:
 		returnCode := snPkts.RC_ACCEPTED
-		topicID, err := h.registerTopic(string(snMsg.TopicName))
+		topicID, err := h.registerTopic(snMsg.TopicName)
 		if err != nil {
 			// The only reason registerTopic can return an error is when all
 			// the available TopicIDs are already used. The MQTT-SN specification

--- a/transactions/transaction_store.go
+++ b/transactions/transaction_store.go
@@ -2,8 +2,6 @@ package transactions
 
 import (
 	"sync"
-
-	pkts "github.com/energomonitor/bisquitt/packets1"
 )
 
 // TransactionStore stores transactions by MessageID or MessageType
@@ -14,14 +12,14 @@ import (
 type TransactionStore struct {
 	sync.RWMutex
 	byMsgID   map[uint16]Transaction
-	byMsgType map[pkts.MessageType]Transaction
+	byMsgType map[uint8]Transaction
 }
 
 // NewTransactionStore creates a new transaction store.
 func NewTransactionStore() *TransactionStore {
 	return &TransactionStore{
 		byMsgID:   make(map[uint16]Transaction),
-		byMsgType: make(map[pkts.MessageType]Transaction),
+		byMsgType: make(map[uint8]Transaction),
 	}
 }
 
@@ -33,7 +31,7 @@ func (ts *TransactionStore) Store(msgID uint16, transaction Transaction) {
 }
 
 // StoreByType inserts a new transaction to the store by the MessageType.
-func (ts *TransactionStore) StoreByType(msgType pkts.MessageType, transaction Transaction) {
+func (ts *TransactionStore) StoreByType(msgType uint8, transaction Transaction) {
 	ts.Lock()
 	defer ts.Unlock()
 	ts.byMsgType[msgType] = transaction
@@ -48,7 +46,7 @@ func (ts *TransactionStore) Get(msgID uint16) (Transaction, bool) {
 }
 
 // GetByType retrieves a transaction from the store by the MessageType.
-func (ts *TransactionStore) GetByType(msgType pkts.MessageType) (Transaction, bool) {
+func (ts *TransactionStore) GetByType(msgType uint8) (Transaction, bool) {
 	ts.Lock()
 	defer ts.Unlock()
 	transaction, ok := ts.byMsgType[msgType]
@@ -63,7 +61,7 @@ func (ts *TransactionStore) Delete(msgID uint16) {
 }
 
 // DeleteByType removes a transaction from the store by the MessageType.
-func (ts *TransactionStore) DeleteByType(msgType pkts.MessageType) {
+func (ts *TransactionStore) DeleteByType(msgType uint8) {
 	ts.Lock()
 	defer ts.Unlock()
 	delete(ts.byMsgType, msgType)


### PR DESCRIPTION
`TransactionsStore` must be usable with both v.1 and v.2 packets => I'm replacing `packets1.MessageType` with general `uint8` in its API.