### PR TITLE
client: Fix errors returned from API functions

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -338,7 +338,7 @@ func (c *Client) Connect() error {
 				return err
 			}
 		case <-c.groupCtx.Done():
-			return context.Canceled
+			return c.group.Wait()
 		}
 	}
 
@@ -360,7 +360,7 @@ func (c *Client) Register(topic string) error {
 	case <-transaction.Done():
 		return transaction.Err()
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }
 
@@ -378,7 +378,7 @@ func (c *Client) subscribe(topicName string, topicIDType uint8, topicID uint16, 
 	case <-transaction.Done():
 		return transaction.Err()
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }
 
@@ -413,7 +413,7 @@ func (c *Client) unsubscribe(topicName string, topicIDType uint8, topicID uint16
 	case <-transaction.Done():
 		return transaction.Err()
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }
 
@@ -462,7 +462,7 @@ func (c *Client) publish(topicIDType uint8, topicID uint16, qos uint8, retain bo
 	case <-transaction.Done():
 		return transaction.Err()
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }
 
@@ -504,7 +504,7 @@ func (c *Client) Ping() error {
 	case <-transaction.Done():
 		return transaction.Err()
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }
 
@@ -519,7 +519,7 @@ func (c *Client) Sleep(duration time.Duration) error {
 	case <-transaction.Done():
 		return transaction.Err()
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }
 
@@ -557,6 +557,6 @@ func (c *Client) Disconnect() error {
 		c.cancel()
 		return nil
 	case <-c.groupCtx.Done():
-		return context.Canceled
+		return c.group.Wait()
 	}
 }


### PR DESCRIPTION
If an error appears inside any of the the `Client.group` goroutines,
the failed goroutine returns a non-nil `error` and the whole
`Client.group` is cancelled using `Client.groupCtx`. I.e. this condition
is signalized by closed `Client.groupCtx.Done()` channel.

The `Client`'s API functions should get the error using
`Client.group.Wait()` call and return it to the caller.
There's no point in returning `context.Canceled` because
`Client.group.Wait()` must eventually return in such condition.