### PR TITLE
Uncapitalize all error strings

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1896,7 +1896,7 @@ func testRead(conn net.Conn, timeout time.Duration) ([]byte, error) {
 	buff := make([]byte, maxTestPktLength)
 	err := conn.SetReadDeadline(time.Now().Add(timeout))
 	if err != nil {
-		return nil, fmt.Errorf("Can't set read deadline on MQTT-SN connection: %s", err)
+		return nil, fmt.Errorf("can't set read deadline on MQTT-SN connection: %s", err)
 	}
 
 	n, err := conn.Read(buff)

--- a/client/net.go
+++ b/client/net.go
@@ -100,19 +100,19 @@ func (c *Client) topicForPublish(pkt *pkts.Publish) (string, error) {
 		topic, ok = findTopic(pkt.TopicID, c.registeredTopics)
 		c.registeredTopicsLock.RUnlock()
 		if !ok {
-			return "", fmt.Errorf("Invalid topic ID: %d", pkt.TopicID)
+			return "", fmt.Errorf("invalid topic ID: %d", pkt.TopicID)
 		}
 	case pkts.TIT_PREDEFINED:
 		var ok bool
 		topic, ok = c.cfg.PredefinedTopics.GetTopicName(c.cfg.ClientID, pkt.TopicID)
 		if !ok {
-			return "", fmt.Errorf("Invalid predefined topic ID: %d", pkt.TopicID)
+			return "", fmt.Errorf("invalid predefined topic ID: %d", pkt.TopicID)
 		}
 	case pkts.TIT_SHORT:
 		topic = pkts.DecodeShortTopic(pkt.TopicID)
 
 	default:
-		return "", fmt.Errorf("Invalid Topic ID Type: %d", pkt.TopicIDType)
+		return "", fmt.Errorf("invalid Topic ID Type: %d", pkt.TopicIDType)
 	}
 
 	return topic, nil
@@ -301,6 +301,6 @@ func (c *Client) handlePacket(pktx pkts.Packet) error {
 		return nil
 
 	default:
-		return fmt.Errorf("Unhandled MQTT-SN packet: %v", pktx)
+		return fmt.Errorf("unhandled MQTT-SN packet: %v", pktx)
 	}
 }

--- a/client/subscribe_transaction.go
+++ b/client/subscribe_transaction.go
@@ -69,7 +69,7 @@ func (t *subscribeTransaction) Suback(suback *pkts.Suback) {
 		var ok bool
 		topicName, ok = t.client.cfg.PredefinedTopics.GetTopicName(t.client.cfg.ClientID, subscribe.TopicID)
 		if !ok {
-			t.Fail(fmt.Errorf("Invalid predefined topic ID: %d", subscribe.TopicID))
+			t.Fail(fmt.Errorf("invalid predefined topic ID: %d", subscribe.TopicID))
 			return
 		}
 
@@ -78,7 +78,7 @@ func (t *subscribeTransaction) Suback(suback *pkts.Suback) {
 		break
 
 	default:
-		t.Fail(fmt.Errorf("Invalid Topic ID Type: %d", subscribe.TopicIDType))
+		t.Fail(fmt.Errorf("invalid Topic ID Type: %d", subscribe.TopicIDType))
 		return
 	}
 

--- a/client/unsubscribe_transaction.go
+++ b/client/unsubscribe_transaction.go
@@ -46,7 +46,7 @@ func (t *unsubscribeTransaction) Unsuback(_ *pkts.Unsuback) {
 		var ok bool
 		topicName, ok = t.client.cfg.PredefinedTopics.GetTopicName(t.client.cfg.ClientID, unsubscribe.TopicID)
 		if !ok {
-			t.Fail(fmt.Errorf("Invalid predefined topic ID: %d", unsubscribe.TopicID))
+			t.Fail(fmt.Errorf("invalid predefined topic ID: %d", unsubscribe.TopicID))
 			return
 		}
 
@@ -54,7 +54,7 @@ func (t *unsubscribeTransaction) Unsuback(_ *pkts.Unsuback) {
 		topicName = pkts.DecodeShortTopic(unsubscribe.TopicID)
 
 	default:
-		t.Fail(fmt.Errorf("Invalid Topic ID Type: %d", unsubscribe.TopicIDType))
+		t.Fail(fmt.Errorf("invalid Topic ID Type: %d", unsubscribe.TopicIDType))
 		return
 	}
 

--- a/cmd/bisquitt-sub/actions.go
+++ b/cmd/bisquitt-sub/actions.go
@@ -152,14 +152,14 @@ func handleAction() cli.ActionFunc {
 		if c.IsSet(WillTopicFlag) {
 			willTopic := c.String(WillTopicFlag)
 			if willTopic == "" {
-				return errors.New("Will topic must not be empty if set")
+				return errors.New("will topic must not be empty if set")
 			}
 			clientCfg.WillTopic = willTopic
 			clientCfg.WillPayload = []byte(c.String(WillMessageFlag))
 
 			qos := c.Uint(WillQOSFlag)
 			if qos > 2 {
-				return fmt.Errorf("Will QOS must be 0-2, got %d", qos)
+				return fmt.Errorf("will QOS must be 0-2, got %d", qos)
 			}
 			clientCfg.WillQOS = uint8(qos)
 			clientCfg.WillRetained = c.Bool(WillRetainFlag)

--- a/gateway/connect_transaction.go
+++ b/gateway/connect_transaction.go
@@ -94,7 +94,7 @@ func (t *connectTransaction) Auth(snMsg *snPkts.Auth) error {
 		if err := t.SendConnack(snPkts.RC_NOT_SUPPORTED); err != nil {
 			return err
 		}
-		err := fmt.Errorf("Unknown auth method: %#v.", snMsg.Method)
+		err := fmt.Errorf("unknown auth method: %#v", snMsg.Method)
 		t.Fail(err)
 		return err
 	}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1374,7 +1374,7 @@ func testRead(connID string, conn net.Conn, timeout time.Duration) ([]byte, erro
 	buff := make([]byte, maxTestPktLength)
 	err := conn.SetReadDeadline(time.Now().Add(timeout))
 	if err != nil {
-		return nil, fmt.Errorf("Can't set read deadline on %s connection: %s", connID, err)
+		return nil, fmt.Errorf("can't set read deadline on %s connection: %s", connID, err)
 	}
 
 	n, err := conn.Read(buff)

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -736,7 +736,7 @@ func (h *handler) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 	// Client REGISTER transaction.
 	case *snPkts.Register:
 		returnCode := snPkts.RC_ACCEPTED
-		topicID, err := h.registerTopic(string(snMsg.TopicName))
+		topicID, err := h.registerTopic(snMsg.TopicName)
 		if err != nil {
 			// The only reason registerTopic can return an error is when all
 			// the available TopicIDs are already used. The MQTT-SN specification

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -240,14 +240,14 @@ func (h *handler) handleClientPublish(ctx context.Context, snPublish *snPkts.Pub
 	case snPkts.TIT_REGISTERED:
 		topicx, ok := h.registeredTopics.Load(snPublish.TopicID)
 		if !ok {
-			return fmt.Errorf("Unknown topic id %d", snPublish.TopicID)
+			return fmt.Errorf("unknown topic id %d", snPublish.TopicID)
 		}
 		topic = topicx.(string)
 	case snPkts.TIT_PREDEFINED:
 		var ok bool
 		topic, ok = h.predefinedTopics.GetTopicName(h.clientID, snPublish.TopicID)
 		if !ok {
-			return fmt.Errorf("Unknown topic id %d", snPublish.TopicID)
+			return fmt.Errorf("unknown topic id %d", snPublish.TopicID)
 		}
 	case snPkts.TIT_SHORT:
 		topic = snPkts.DecodeShortTopic(snPublish.TopicID)
@@ -327,7 +327,7 @@ func (h *handler) handleBrokerPublish(ctx context.Context, mqPublish *mqttPacket
 	case 2:
 		transaction = newBrokerPublishQOS2Transaction(ctx, h, msgID)
 	default:
-		return fmt.Errorf("Invalid QoS in %v", mqPublish)
+		return fmt.Errorf("invalid QoS in %v", mqPublish)
 	}
 
 	var snMsg snPkts.Packet
@@ -435,7 +435,7 @@ func (h *handler) handleMqtt(ctx context.Context, pkt mqttPackets.ControlPacket)
 		return transaction.Pubrel(mqMsg)
 
 	default:
-		return fmt.Errorf("Unsupported MQTT packet type: %v", pkt)
+		return fmt.Errorf("unsupported MQTT packet type: %v", pkt)
 	}
 }
 
@@ -609,7 +609,7 @@ func (h *handler) handleSubscribe(ctx context.Context, snSubscribe *snPkts.Subsc
 		var ok bool
 		topic, ok = h.predefinedTopics.GetTopicName(h.clientID, snSubscribe.TopicID)
 		if !ok {
-			return fmt.Errorf("Unknown topic id %d", snSubscribe.TopicID)
+			return fmt.Errorf("unknown topic id %d", snSubscribe.TopicID)
 		}
 		topicID = snSubscribe.TopicID
 	case snPkts.TIT_SHORT:
@@ -638,7 +638,7 @@ func (h *handler) handleUnsubscribe(_ context.Context, snUnsubscribe *snPkts.Uns
 		var ok bool
 		topic, ok = h.predefinedTopics.GetTopicName(h.clientID, snUnsubscribe.TopicID)
 		if !ok {
-			return fmt.Errorf("Unknown topic id %d", snUnsubscribe.TopicID)
+			return fmt.Errorf("unknown topic id %d", snUnsubscribe.TopicID)
 		}
 	case snPkts.TIT_SHORT:
 		topic = snPkts.DecodeShortTopic(snUnsubscribe.TopicID)
@@ -858,7 +858,7 @@ func (h *handler) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 		return nil
 
 	default:
-		return fmt.Errorf("Unsupported MQTT-SN packet type: %v", pkt)
+		return fmt.Errorf("unsupported MQTT-SN packet type: %v", pkt)
 	}
 }
 
@@ -912,7 +912,7 @@ func (h *handler) snReceive() (snPkts.Packet, error) {
 	pktBuf := buffer[:n]
 
 	if len(pktBuf) < 2 {
-		return nil, errors.New("Illegal packet: too short")
+		return nil, errors.New("illegal packet: too short")
 	}
 
 	pktReader := bytes.NewReader(pktBuf)

--- a/gateway/subscribe_transaction.go
+++ b/gateway/subscribe_transaction.go
@@ -39,7 +39,7 @@ func newSubscribeTransaction(ctx context.Context, h *handler, msgID uint16, topi
 
 func (t *subscribeTransaction) Suback(mqSuback *mqttPackets.SubackPacket) error {
 	if len(mqSuback.ReturnCodes) != 1 {
-		err := fmt.Errorf("Unexpected ReturnCodes length in MQTT/SUBACK: %d", len(mqSuback.ReturnCodes))
+		err := fmt.Errorf("unexpected ReturnCodes length in MQTT/SUBACK: %d", len(mqSuback.ReturnCodes))
 		t.Fail(err)
 		return err
 	}

--- a/packets1/auth.go
+++ b/packets1/auth.go
@@ -52,7 +52,7 @@ func NewAuthPlain(user string, password []byte) *Auth {
 func DecodePlain(auth *Auth) (string, []byte, error) {
 	dataParts := bytes.Split(auth.Data, []byte{0})
 	if len(dataParts) != 3 {
-		return "", nil, fmt.Errorf("Invalid PLAIN auth data format: %v.", auth.Data)
+		return "", nil, fmt.Errorf("invalid PLAIN auth data format: %v.", auth.Data)
 	}
 	// NOTE: PLAIN first part (authorization identity) not used.
 	return string(dataParts[1]), dataParts[2], nil


### PR DESCRIPTION
According to the Go convention, all `error`s returned from functions
should begin with a lower case letter.

On the contrary, errors logged using `util.Logger.Error` should be
capitalized.

+ one unrelated one-line correction which doesn't deserve its own PR...