### PR TITLE
Unify `import` formatting

### DIFF
--- a/client/broker_publish_qos2_transaction.go
+++ b/client/broker_publish_qos2_transaction.go
@@ -12,14 +12,14 @@ package client
 import (
 	"fmt"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
 type brokerPublishQOS2Transaction struct {
 	*transactions.TransactionBase
 	client  *Client
-	publish *pkts.Publish
+	publish *pkts1.Publish
 }
 
 func newBrokerPublishQOS2Transaction(client *Client, msgID uint16) *brokerPublishQOS2Transaction {
@@ -36,15 +36,15 @@ func newBrokerPublishQOS2Transaction(client *Client, msgID uint16) *brokerPublis
 	}
 }
 
-func (t *brokerPublishQOS2Transaction) Publish(publish *pkts.Publish) error {
+func (t *brokerPublishQOS2Transaction) Publish(publish *pkts1.Publish) error {
 	t.publish = publish
-	pubrec := pkts.NewPubrec()
+	pubrec := pkts1.NewPubrec()
 	pubrec.CopyMessageID(publish)
 	return t.client.send(pubrec)
 }
 
-func (t *brokerPublishQOS2Transaction) Pubrel(pubrel *pkts.Pubrel) error {
-	pubcomp := pkts.NewPubcomp()
+func (t *brokerPublishQOS2Transaction) Pubrel(pubrel *pkts1.Pubrel) error {
+	pubcomp := pkts1.NewPubcomp()
 	pubcomp.CopyMessageID(pubrel)
 	topic, err := t.client.topicForPublish(t.publish)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -64,7 +64,7 @@ import (
 	"sync"
 	"time"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -137,7 +137,7 @@ func NewClient(log util.Logger, cfg *ClientConfig) *Client {
 		state:            &state,
 		stateChangeCh:    make(chan util.ClientState, 1),
 		log:              log,
-		msgID:            util.NewIDSequence(pkts.MinMessageID, pkts.MaxMessageID),
+		msgID:            util.NewIDSequence(pkts1.MinMessageID, pkts1.MaxMessageID),
 	}
 }
 
@@ -295,20 +295,20 @@ func (c *Client) notifyStateChange(s util.ClientState) {
 // MQTT-SN specification, this must be the first packet the client sends
 // unless it's a PUBLISH packet with QoS = -1.
 func (c *Client) Connect() error {
-	connect := pkts.NewConnect(
+	connect := pkts1.NewConnect(
 		[]byte(c.cfg.ClientID),
 		c.cfg.CleanSession,
 		c.cfg.WillTopic != "",
 		uint16(c.cfg.KeepAlive.Seconds()))
 
-	var auth *pkts.Auth
+	var auth *pkts1.Auth
 	if c.cfg.User != "" {
-		auth = pkts.NewAuthPlain(c.cfg.User, c.cfg.Password)
+		auth = pkts1.NewAuthPlain(c.cfg.User, c.cfg.Password)
 	}
 
 	for i := uint(0); i < c.cfg.RetryCount+1; i++ {
 		transaction := newConnectTransaction(c.groupCtx, c)
-		c.transactions.StoreByType(pkts.CONNECT, transaction)
+		c.transactions.StoreByType(pkts1.CONNECT, transaction)
 
 		if err := c.send(connect); err != nil {
 			return err
@@ -342,7 +342,7 @@ func (c *Client) Connect() error {
 func (c *Client) Register(topic string) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newRegisterTransaction(c, msgID, topic)
-	register := pkts.NewRegister(0, topic)
+	register := pkts1.NewRegister(0, topic)
 	register.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, register)
@@ -360,7 +360,7 @@ func (c *Client) Register(topic string) error {
 func (c *Client) subscribe(topicName string, topicIDType uint8, topicID uint16, qos uint8, callback MessageHandlerFunc) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newSubscribeTransaction(c, msgID, callback)
-	subscribe := pkts.NewSubscribe(topicID, topicIDType, []byte(topicName), qos, false)
+	subscribe := pkts1.NewSubscribe(topicID, topicIDType, []byte(topicName), qos, false)
 	subscribe.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, subscribe)
@@ -379,23 +379,23 @@ func (c *Client) subscribe(topicName string, topicIDType uint8, topicID uint16, 
 // long, it's treated as a short topic. The received packets are passed to the
 // provided callback.
 func (c *Client) Subscribe(topic string, qos uint8, callback MessageHandlerFunc) error {
-	if pkts.IsShortTopic(topic) {
-		return c.subscribe("", pkts.TIT_SHORT, pkts.EncodeShortTopic(topic), qos, callback)
+	if pkts1.IsShortTopic(topic) {
+		return c.subscribe("", pkts1.TIT_SHORT, pkts1.EncodeShortTopic(topic), qos, callback)
 	} else {
-		return c.subscribe(topic, pkts.TIT_STRING, 0, qos, callback)
+		return c.subscribe(topic, pkts1.TIT_STRING, 0, qos, callback)
 	}
 }
 
 // SubscribePredefined subscribes to a predefined topic with the provided QoS.
 // The received packets are passed to the provided callback.
 func (c *Client) SubscribePredefined(topicID uint16, qos uint8, callback MessageHandlerFunc) error {
-	return c.subscribe("", pkts.TIT_PREDEFINED, topicID, qos, callback)
+	return c.subscribe("", pkts1.TIT_PREDEFINED, topicID, qos, callback)
 }
 
 func (c *Client) unsubscribe(topicName string, topicIDType uint8, topicID uint16) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newUnsubscribeTransaction(c, msgID)
-	unsubscribe := pkts.NewUnsubscribe(topicID, topicIDType, []byte(topicName))
+	unsubscribe := pkts1.NewUnsubscribe(topicID, topicIDType, []byte(topicName))
 	unsubscribe.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, unsubscribe)
@@ -413,20 +413,20 @@ func (c *Client) unsubscribe(topicName string, topicIDType uint8, topicID uint16
 // Unsubscribe unsubscribes from a topic. If the topic is 2 characters long,
 // it's treated as a short topic.
 func (c *Client) Unsubscribe(topic string) error {
-	if pkts.IsShortTopic(topic) {
-		return c.unsubscribe("", pkts.TIT_SHORT, pkts.EncodeShortTopic(topic))
+	if pkts1.IsShortTopic(topic) {
+		return c.unsubscribe("", pkts1.TIT_SHORT, pkts1.EncodeShortTopic(topic))
 	} else {
-		return c.unsubscribe(topic, pkts.TIT_STRING, 0)
+		return c.unsubscribe(topic, pkts1.TIT_STRING, 0)
 	}
 }
 
 // UnsubscribePredefined unsubscribes from a predefined topic.
 func (c *Client) UnsubscribePredefined(topicID uint16) error {
-	return c.unsubscribe("", pkts.TIT_PREDEFINED, topicID)
+	return c.unsubscribe("", pkts1.TIT_PREDEFINED, topicID)
 }
 
 func (c *Client) publish(topicIDType uint8, topicID uint16, qos uint8, retain bool, payload []byte) error {
-	publish := pkts.NewPublish(topicID, topicIDType, payload, qos, retain, false)
+	publish := pkts1.NewPublish(topicID, topicIDType, payload, qos, retain, false)
 	msgID, _ := c.msgID.Next()
 	publish.SetMessageID(msgID)
 
@@ -463,11 +463,11 @@ func (c *Client) publish(topicIDType uint8, topicID uint16, qos uint8, retain bo
 func (c *Client) Publish(topic string, qos uint8, retain bool, payload []byte) error {
 	var topicIDType uint8
 	var topicID uint16
-	if pkts.IsShortTopic(topic) {
-		topicIDType = pkts.TIT_SHORT
-		topicID = pkts.EncodeShortTopic(topic)
+	if pkts1.IsShortTopic(topic) {
+		topicIDType = pkts1.TIT_SHORT
+		topicID = pkts1.EncodeShortTopic(topic)
 	} else {
-		topicIDType = pkts.TIT_REGISTERED
+		topicIDType = pkts1.TIT_REGISTERED
 		var ok bool
 		c.registeredTopicsLock.RLock()
 		topicID, ok = c.registeredTopics[topic]
@@ -481,14 +481,14 @@ func (c *Client) Publish(topic string, qos uint8, retain bool, payload []byte) e
 
 // PublishPredefined publishes a message to the provided predefined topic.
 func (c *Client) PublishPredefined(topicID uint16, qos uint8, retain bool, payload []byte) error {
-	return c.publish(pkts.TIT_PREDEFINED, topicID, qos, retain, payload)
+	return c.publish(pkts1.TIT_PREDEFINED, topicID, qos, retain, payload)
 }
 
 // Ping sends a PING packet to the MQTT-SN gateway.
 func (c *Client) Ping() error {
 	transaction := newPingTransaction(c)
-	ping := pkts.NewPingreq(nil)
-	c.transactions.StoreByType(pkts.PINGREQ, transaction)
+	ping := pkts1.NewPingreq(nil)
+	c.transactions.StoreByType(pkts1.PINGREQ, transaction)
 	transaction.Proceed(nil, ping)
 	if err := c.send(ping); err != nil {
 		transaction.Fail(err)
@@ -504,7 +504,7 @@ func (c *Client) Ping() error {
 // Sleep informs the MQTT-SN gateway that the client is going to sleep.
 func (c *Client) Sleep(duration time.Duration) error {
 	transaction := newSleepTransaction(c, duration)
-	c.transactions.StoreByType(pkts.DISCONNECT, transaction)
+	c.transactions.StoreByType(pkts1.DISCONNECT, transaction)
 	if err := transaction.Sleep(); err != nil {
 		return err
 	}
@@ -528,8 +528,8 @@ func (c *Client) Disconnect() error {
 		return nil
 	}
 	transaction := newDisconnectTransaction(c)
-	disconnect := pkts.NewDisconnect(0)
-	c.transactions.StoreByType(pkts.DISCONNECT, transaction)
+	disconnect := pkts1.NewDisconnect(0)
+	c.transactions.StoreByType(pkts1.DISCONNECT, transaction)
 	transaction.Proceed(awaitingDisconnect, disconnect)
 	if err := c.send(disconnect); err != nil {
 		transaction.Fail(err)

--- a/client/client.go
+++ b/client/client.go
@@ -64,13 +64,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pion/dtls/v2"
+	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
+	"golang.org/x/sync/errgroup"
+
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
-	"github.com/pion/dtls/v2"
-	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
-	"golang.org/x/sync/errgroup"
 )
 
 type ClientConfig struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/client/connect_transaction.go
+++ b/client/connect_transaction.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
 )
@@ -21,7 +21,7 @@ func newConnectTransaction(ctx context.Context, client *Client) *connectTransact
 		TimedTransaction: transactions.NewTimedTransaction(
 			ctx, client.cfg.ConnectTimeout,
 			func() {
-				client.transactions.DeleteByType(pkts.CONNECT)
+				client.transactions.DeleteByType(pkts1.CONNECT)
 				tLog.Debug("Deleted.")
 			},
 		),
@@ -29,8 +29,8 @@ func newConnectTransaction(ctx context.Context, client *Client) *connectTransact
 	}
 }
 
-func (t *connectTransaction) Connack(connack *pkts.Connack) {
-	if connack.ReturnCode != pkts.RC_ACCEPTED {
+func (t *connectTransaction) Connack(connack *pkts1.Connack) {
+	if connack.ReturnCode != pkts1.RC_ACCEPTED {
 		t.Fail(fmt.Errorf("connection rejected: %s", connack.ReturnCode))
 		return
 	}

--- a/client/disconnect_transaction.go
+++ b/client/disconnect_transaction.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -18,10 +18,10 @@ func newDisconnectTransaction(client *Client) *disconnectTransaction {
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastMsg interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts.Packet))
+					return client.send(lastMsg.(pkts1.Packet))
 				},
 				func() {
-					client.transactions.DeleteByType(pkts.DISCONNECT)
+					client.transactions.DeleteByType(pkts1.DISCONNECT)
 					tLog.Debug("Deleted.")
 				},
 			),
@@ -31,6 +31,6 @@ func newDisconnectTransaction(client *Client) *disconnectTransaction {
 	}
 }
 
-func (t *disconnectTransaction) Disconnect(disconnect *pkts.Disconnect) {
+func (t *disconnectTransaction) Disconnect(disconnect *pkts1.Disconnect) {
 	t.Success()
 }

--- a/client/message_handlers.go
+++ b/client/message_handlers.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 	"sync"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 )
 
 // Subscribed message handler callback type.
-type MessageHandlerFunc func(client *Client, topic string, pkt *pkts.Publish)
+type MessageHandlerFunc func(client *Client, topic string, pkt *pkts1.Publish)
 
 type messageHandler struct {
 	route    []string
@@ -31,7 +31,7 @@ func (mhs *messageHandlers) delete(route []string) {
 	mhs.handlers.Delete(join(route))
 }
 
-func (mhs *messageHandlers) handle(client *Client, topic string, pubPkt *pkts.Publish) {
+func (mhs *messageHandlers) handle(client *Client, topic string, pubPkt *pkts1.Publish) {
 	var callback MessageHandlerFunc
 	route := split(topic)
 	mhs.handlers.Range(func(key, value interface{}) bool {

--- a/client/net.go
+++ b/client/net.go
@@ -6,10 +6,10 @@ import (
 	"net"
 	"time"
 
+	dtlsProtocol "github.com/pion/dtls/v2/pkg/protocol"
+
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/util"
-
-	dtlsProtocol "github.com/pion/dtls/v2/pkg/protocol"
 )
 
 func (c *Client) send(pkt pkts1.Packet) error {

--- a/client/ping_transaction.go
+++ b/client/ping_transaction.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -18,10 +18,10 @@ func newPingTransaction(client *Client) *pingTransaction {
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastMsg interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts.Packet))
+					return client.send(lastMsg.(pkts1.Packet))
 				},
 				func() {
-					client.transactions.DeleteByType(pkts.PINGREQ)
+					client.transactions.DeleteByType(pkts1.PINGREQ)
 					tLog.Debug("Deleted.")
 				},
 			),
@@ -31,6 +31,6 @@ func newPingTransaction(client *Client) *pingTransaction {
 	}
 }
 
-func (t *pingTransaction) Pingresp(pingresp *pkts.Pingresp) {
+func (t *pingTransaction) Pingresp(pingresp *pkts1.Pingresp) {
 	t.Success()
 }

--- a/client/publish_qos1_transaction.go
+++ b/client/publish_qos1_transaction.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -20,7 +20,7 @@ func newPublishQOS1Transaction(client *Client, msgID uint16) *publishQOS1Transac
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastMsg interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts.Packet))
+					return client.send(lastMsg.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)
@@ -33,7 +33,7 @@ func newPublishQOS1Transaction(client *Client, msgID uint16) *publishQOS1Transac
 	}
 }
 
-func (t *publishQOS1Transaction) Puback(puback *pkts.Puback) {
+func (t *publishQOS1Transaction) Puback(puback *pkts1.Puback) {
 	if t.State != awaitingPuback {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, puback)
 		return

--- a/client/publish_qos2_transaction.go
+++ b/client/publish_qos2_transaction.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -20,7 +20,7 @@ func newPublishQOS2Transaction(client *Client, msgID uint16) *publishQOS2Transac
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastMsg interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts.Packet))
+					return client.send(lastMsg.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)
@@ -33,12 +33,12 @@ func newPublishQOS2Transaction(client *Client, msgID uint16) *publishQOS2Transac
 	}
 }
 
-func (t *publishQOS2Transaction) Pubrec(pubrec *pkts.Pubrec) error {
+func (t *publishQOS2Transaction) Pubrec(pubrec *pkts1.Pubrec) error {
 	if t.State != awaitingPubrec {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, pubrec)
 		return nil
 	}
-	pubrel := pkts.NewPubrel()
+	pubrel := pkts1.NewPubrel()
 	pubrel.CopyMessageID(pubrec)
 	t.Proceed(awaitingPubcomp, pubrel)
 	if err := t.client.send(pubrel); err != nil {
@@ -47,7 +47,7 @@ func (t *publishQOS2Transaction) Pubrec(pubrec *pkts.Pubrec) error {
 	return nil
 }
 
-func (t *publishQOS2Transaction) Pubcomp(pubcomp *pkts.Pubcomp) {
+func (t *publishQOS2Transaction) Pubcomp(pubcomp *pkts1.Pubcomp) {
 	if t.State != awaitingPubcomp {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, pubcomp)
 		return

--- a/client/register_transaction.go
+++ b/client/register_transaction.go
@@ -3,7 +3,7 @@ package client
 import (
 	"fmt"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -20,7 +20,7 @@ func newRegisterTransaction(client *Client, msgID uint16, topic string) *registe
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastMsg interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts.Packet))
+					return client.send(lastMsg.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)
@@ -33,13 +33,13 @@ func newRegisterTransaction(client *Client, msgID uint16, topic string) *registe
 	}
 }
 
-func (t *registerTransaction) Regack(regack *pkts.Regack) {
-	if regack.ReturnCode != pkts.RC_ACCEPTED {
+func (t *registerTransaction) Regack(regack *pkts1.Regack) {
+	if regack.ReturnCode != pkts1.RC_ACCEPTED {
 		t.Fail(fmt.Errorf("registration rejected with code %d", regack.ReturnCode))
 		return
 	}
 
-	register := t.Data.(*pkts.Register)
+	register := t.Data.(*pkts1.Register)
 	t.client.registeredTopicsLock.Lock()
 	t.client.registeredTopics[register.TopicName] = regack.TopicID
 	t.client.registeredTopicsLock.Unlock()

--- a/client/transaction.go
+++ b/client/transaction.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
 )
@@ -28,10 +28,10 @@ type transaction struct {
 
 // Transactions involving DISCONNECT packet.
 type transactionWithDisconnect interface {
-	Disconnect(*pkts.Disconnect)
+	Disconnect(*pkts1.Disconnect)
 }
 
 // Transactions involving PINGRESP packet.
 type transactionWithPingresp interface {
-	Pingresp(pingresp *pkts.Pingresp)
+	Pingresp(pingresp *pkts1.Pingresp)
 }

--- a/client/unsubscribe_transaction.go
+++ b/client/unsubscribe_transaction.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -21,7 +21,7 @@ func newUnsubscribeTransaction(client *Client, msgID uint16) *unsubscribeTransac
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastMsg interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts.Packet))
+					return client.send(lastMsg.(pkts1.Packet))
 				},
 				func() {
 					tLog.Debug("Deleted.")
@@ -34,15 +34,15 @@ func newUnsubscribeTransaction(client *Client, msgID uint16) *unsubscribeTransac
 	}
 }
 
-func (t *unsubscribeTransaction) Unsuback(_ *pkts.Unsuback) {
+func (t *unsubscribeTransaction) Unsuback(_ *pkts1.Unsuback) {
 	var topicName string
-	unsubscribe := t.Data.(*pkts.Unsubscribe)
+	unsubscribe := t.Data.(*pkts1.Unsubscribe)
 
 	switch unsubscribe.TopicIDType {
-	case pkts.TIT_STRING:
+	case pkts1.TIT_STRING:
 		topicName = string(unsubscribe.TopicName)
 
-	case pkts.TIT_PREDEFINED:
+	case pkts1.TIT_PREDEFINED:
 		var ok bool
 		topicName, ok = t.client.cfg.PredefinedTopics.GetTopicName(t.client.cfg.ClientID, unsubscribe.TopicID)
 		if !ok {
@@ -50,8 +50,8 @@ func (t *unsubscribeTransaction) Unsuback(_ *pkts.Unsuback) {
 			return
 		}
 
-	case pkts.TIT_SHORT:
-		topicName = pkts.DecodeShortTopic(unsubscribe.TopicID)
+	case pkts1.TIT_SHORT:
+		topicName = pkts1.DecodeShortTopic(unsubscribe.TopicID)
 
 	default:
 		t.Fail(fmt.Errorf("invalid Topic ID Type: %d", unsubscribe.TopicIDType))

--- a/cmd/bisquitt-pub/actions.go
+++ b/cmd/bisquitt-pub/actions.go
@@ -13,11 +13,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	snClient "github.com/energomonitor/bisquitt/client"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
 	cryptoutils "github.com/energomonitor/bisquitt/util/crypto"
-	"github.com/urfave/cli/v2"
 )
 
 func handleAction() cli.ActionFunc {

--- a/cmd/bisquitt-pub/application.go
+++ b/cmd/bisquitt-pub/application.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/energomonitor/bisquitt"
 	"github.com/urfave/cli/v2"
+
+	"github.com/energomonitor/bisquitt"
 )
 
 const (

--- a/cmd/bisquitt-sub/actions.go
+++ b/cmd/bisquitt-sub/actions.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	snClient "github.com/energomonitor/bisquitt/client"
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
 	cryptoutils "github.com/energomonitor/bisquitt/util/crypto"
@@ -201,7 +201,7 @@ func handleAction() cli.ActionFunc {
 			return err
 		}
 
-		handler := func(client *snClient.Client, topic string, msg *pkts.Publish) {
+		handler := func(client *snClient.Client, topic string, msg *pkts1.Publish) {
 			var flags []string
 			if msg.Retain {
 				flags = append(flags, "retained")

--- a/cmd/bisquitt-sub/actions.go
+++ b/cmd/bisquitt-sub/actions.go
@@ -15,12 +15,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	snClient "github.com/energomonitor/bisquitt/client"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
 	cryptoutils "github.com/energomonitor/bisquitt/util/crypto"
-	"github.com/urfave/cli/v2"
 )
 
 func handleAction() cli.ActionFunc {

--- a/cmd/bisquitt-sub/application.go
+++ b/cmd/bisquitt-sub/application.go
@@ -3,8 +3,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/energomonitor/bisquitt"
 	"github.com/urfave/cli/v2"
+
+	"github.com/energomonitor/bisquitt"
 )
 
 const (

--- a/cmd/bisquitt/actions.go
+++ b/cmd/bisquitt/actions.go
@@ -12,12 +12,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/energomonitor/bisquitt/gateway"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
 	cryptoutils "github.com/energomonitor/bisquitt/util/crypto"
 	"github.com/energomonitor/bisquitt/util/platform"
-	"github.com/urfave/cli/v2"
 )
 
 func handleAction() cli.ActionFunc {

--- a/cmd/bisquitt/application.go
+++ b/cmd/bisquitt/application.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/energomonitor/bisquitt"
 	"github.com/energomonitor/bisquitt/util/platform"
-	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/gateway/broker_publish_qos0_transaction.go
+++ b/gateway/broker_publish_qos0_transaction.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -31,6 +31,6 @@ func newBrokerPublishQOS0Transaction(ctx context.Context, h *handler, msgID uint
 	return t
 }
 
-func (t *brokerPublishQOS0Transaction) Regack(snRegack *snPkts.Regack) error {
+func (t *brokerPublishQOS0Transaction) Regack(snRegack *snPkts1.Regack) error {
 	return t.regack(snRegack, transactionDone)
 }

--- a/gateway/broker_publish_qos1_transaction.go
+++ b/gateway/broker_publish_qos1_transaction.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -45,7 +46,7 @@ func (t *brokerPublishQOS1Transaction) Puback(snPuback *snPkts1.Puback) error {
 		t.Fail(fmt.Errorf("PUBACK return code: %d", snPuback.ReturnCode))
 		return nil
 	}
-	mqPuback := mqttPackets.NewControlPacket(mqttPackets.Puback).(*mqttPackets.PubackPacket)
+	mqPuback := mqPkts.NewControlPacket(mqPkts.Puback).(*mqPkts.PubackPacket)
 	mqPuback.MessageID = snPuback.MessageID()
 	return t.ProceedMQTT(transactionDone, mqPuback)
 }

--- a/gateway/broker_publish_qos1_transaction.go
+++ b/gateway/broker_publish_qos1_transaction.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -32,16 +32,16 @@ func newBrokerPublishQOS1Transaction(ctx context.Context, h *handler, msgID uint
 	return t
 }
 
-func (t *brokerPublishQOS1Transaction) Regack(snRegack *snPkts.Regack) error {
+func (t *brokerPublishQOS1Transaction) Regack(snRegack *snPkts1.Regack) error {
 	return t.regack(snRegack, awaitingPuback)
 }
 
-func (t *brokerPublishQOS1Transaction) Puback(snPuback *snPkts.Puback) error {
+func (t *brokerPublishQOS1Transaction) Puback(snPuback *snPkts1.Puback) error {
 	if t.State != awaitingPuback {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, snPuback)
 		return nil
 	}
-	if snPuback.ReturnCode != snPkts.RC_ACCEPTED {
+	if snPuback.ReturnCode != snPkts1.RC_ACCEPTED {
 		t.Fail(fmt.Errorf("PUBACK return code: %d", snPuback.ReturnCode))
 		return nil
 	}

--- a/gateway/broker_publish_qos2_transaction.go
+++ b/gateway/broker_publish_qos2_transaction.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -41,12 +42,12 @@ func (t *brokerPublishQOS2Transaction) Pubrec(snPubrec *snPkts1.Pubrec) error {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, snPubrec)
 		return nil
 	}
-	mqPubrec := mqttPackets.NewControlPacket(mqttPackets.Pubrec).(*mqttPackets.PubrecPacket)
+	mqPubrec := mqPkts.NewControlPacket(mqPkts.Pubrec).(*mqPkts.PubrecPacket)
 	mqPubrec.MessageID = snPubrec.MessageID()
 	return t.ProceedMQTT(awaitingPubrel, mqPubrec)
 }
 
-func (t *brokerPublishQOS2Transaction) Pubrel(mqPubrel *mqttPackets.PubrelPacket) error {
+func (t *brokerPublishQOS2Transaction) Pubrel(mqPubrel *mqPkts.PubrelPacket) error {
 	if t.State != awaitingPubrel {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, mqPubrel)
 		return nil
@@ -61,7 +62,7 @@ func (t *brokerPublishQOS2Transaction) Pubcomp(snPubcomp *snPkts1.Pubcomp) error
 		t.log.Debug("Unexpected packet in %d: %v", t.State, snPubcomp)
 		return nil
 	}
-	mqPubcomp := mqttPackets.NewControlPacket(mqttPackets.Pubcomp).(*mqttPackets.PubcompPacket)
+	mqPubcomp := mqPkts.NewControlPacket(mqPkts.Pubcomp).(*mqPkts.PubcompPacket)
 	mqPubcomp.MessageID = snPubcomp.MessageID()
 	return t.ProceedMQTT(transactionDone, mqPubcomp)
 }

--- a/gateway/broker_publish_qos2_transaction.go
+++ b/gateway/broker_publish_qos2_transaction.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
 
@@ -32,11 +32,11 @@ func newBrokerPublishQOS2Transaction(ctx context.Context, h *handler, msgID uint
 	return t
 }
 
-func (t *brokerPublishQOS2Transaction) Regack(snRegack *snPkts.Regack) error {
+func (t *brokerPublishQOS2Transaction) Regack(snRegack *snPkts1.Regack) error {
 	return t.regack(snRegack, awaitingPubrec)
 }
 
-func (t *brokerPublishQOS2Transaction) Pubrec(snPubrec *snPkts.Pubrec) error {
+func (t *brokerPublishQOS2Transaction) Pubrec(snPubrec *snPkts1.Pubrec) error {
 	if t.State != awaitingPubrec {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, snPubrec)
 		return nil
@@ -51,12 +51,12 @@ func (t *brokerPublishQOS2Transaction) Pubrel(mqPubrel *mqttPackets.PubrelPacket
 		t.log.Debug("Unexpected packet in %d: %v", t.State, mqPubrel)
 		return nil
 	}
-	snPubrel := snPkts.NewPubrel()
+	snPubrel := snPkts1.NewPubrel()
 	snPubrel.SetMessageID(mqPubrel.MessageID)
 	return t.ProceedSN(awaitingPubcomp, snPubrel)
 }
 
-func (t *brokerPublishQOS2Transaction) Pubcomp(snPubcomp *snPkts.Pubcomp) error {
+func (t *brokerPublishQOS2Transaction) Pubcomp(snPubcomp *snPkts1.Pubcomp) error {
 	if t.State != awaitingPubcomp {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, snPubcomp)
 		return nil

--- a/gateway/broker_publish_transaction.go
+++ b/gateway/broker_publish_transaction.go
@@ -3,7 +3,8 @@ package gateway
 import (
 	"fmt"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -29,7 +30,7 @@ type brokerPublishTransaction interface {
 	transactions.StatefulTransaction
 	SetSNPublish(*snPkts1.Publish)
 	ProceedSN(newState transactionState, snMsg snPkts1.Packet) error
-	ProceedMQTT(newState transactionState, mqMsg mqttPackets.ControlPacket) error
+	ProceedMQTT(newState transactionState, mqMsg mqPkts.ControlPacket) error
 }
 
 type brokerPublishTransactionBase struct {
@@ -69,7 +70,7 @@ func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snMs
 	return nil
 }
 
-func (t *brokerPublishTransactionBase) ProceedMQTT(newState transactionState, mqMsg mqttPackets.ControlPacket) error {
+func (t *brokerPublishTransactionBase) ProceedMQTT(newState transactionState, mqMsg mqPkts.ControlPacket) error {
 	t.Proceed(newState, mqMsg)
 	if err := t.handler.mqttSend(mqMsg); err != nil {
 		t.Fail(err)
@@ -91,9 +92,9 @@ func (t *brokerPublishTransactionBase) resend(pktx interface{}) error {
 			dupMsg.SetDUP(true)
 		}
 		return t.handler.snSend(pkt)
-	case mqttPackets.ControlPacket:
+	case mqPkts.ControlPacket:
 		// PUBLISH is the only packet with DUP in MQTT.
-		if publish, ok := pkt.(*mqttPackets.PublishPacket); ok {
+		if publish, ok := pkt.(*mqPkts.PublishPacket); ok {
 			publish.Dup = true
 		}
 		return t.handler.mqttSend(pkt)

--- a/gateway/broker_publish_transaction.go
+++ b/gateway/broker_publish_transaction.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
 )
@@ -22,42 +22,42 @@ const (
 )
 
 type transactionWithRegack interface {
-	Regack(snRegack *snPkts.Regack) error
+	Regack(snRegack *snPkts1.Regack) error
 }
 
 type brokerPublishTransaction interface {
 	transactions.StatefulTransaction
-	SetSNPublish(*snPkts.Publish)
-	ProceedSN(newState transactionState, snMsg snPkts.Packet) error
+	SetSNPublish(*snPkts1.Publish)
+	ProceedSN(newState transactionState, snMsg snPkts1.Packet) error
 	ProceedMQTT(newState transactionState, mqMsg mqttPackets.ControlPacket) error
 }
 
 type brokerPublishTransactionBase struct {
 	*transactions.RetryTransaction
 	log       util.Logger
-	snPublish *snPkts.Publish
+	snPublish *snPkts1.Publish
 	handler   *handler
 }
 
-func (t *brokerPublishTransactionBase) SetSNPublish(snPublish *snPkts.Publish) {
+func (t *brokerPublishTransactionBase) SetSNPublish(snPublish *snPkts1.Publish) {
 	t.snPublish = snPublish
 }
 
-func (t *brokerPublishTransactionBase) regack(snRegack *snPkts.Regack, newState transactionState) error {
+func (t *brokerPublishTransactionBase) regack(snRegack *snPkts1.Regack, newState transactionState) error {
 	if t.State != awaitingRegack {
 		t.log.Debug("Unexpected packet in %d: %v", t.State, snRegack)
 		return nil
 	}
-	if snRegack.ReturnCode != snPkts.RC_ACCEPTED {
+	if snRegack.ReturnCode != snPkts1.RC_ACCEPTED {
 		t.Fail(fmt.Errorf("REGACK return code: %d", snRegack.ReturnCode))
 		return nil
 	}
-	snRegister := t.Data.(*snPkts.Register)
+	snRegister := t.Data.(*snPkts1.Register)
 	t.handler.registeredTopics.Store(snRegister.TopicID, snRegister.TopicName)
 	return t.ProceedSN(newState, t.snPublish)
 }
 
-func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snMsg snPkts.Packet) error {
+func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snMsg snPkts1.Packet) error {
 	t.Proceed(newState, snMsg)
 	if err := t.handler.snSend(snMsg); err != nil {
 		t.Fail(err)
@@ -85,9 +85,9 @@ func (t *brokerPublishTransactionBase) ProceedMQTT(newState transactionState, mq
 func (t *brokerPublishTransactionBase) resend(pktx interface{}) error {
 	t.log.Debug("Resend.")
 	switch pkt := pktx.(type) {
-	case snPkts.Packet:
+	case snPkts1.Packet:
 		// Set DUP if applicable.
-		if dupMsg, ok := pkt.(snPkts.PacketWithDUP); ok {
+		if dupMsg, ok := pkt.(snPkts1.PacketWithDUP); ok {
 			dupMsg.SetDUP(true)
 		}
 		return t.handler.snSend(pkt)

--- a/gateway/client_publish_qos1_transaction.go
+++ b/gateway/client_publish_qos1_transaction.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
 )
@@ -55,7 +55,7 @@ func (t *clientPublishQOS1Transaction) Puback(mqPuback *mqttPackets.PubackPacket
 	// MQTT-SN PUBACK packet contains ReturnCode field. MQTT PUBACK packet
 	// does not contain it - PUBACK's implicit meaning is "accepted".
 	// See MQTT-SN specification v. 1.2, chapter 5.4.13.
-	snPuback := snPkts.NewPuback(t.topicID, snPkts.RC_ACCEPTED)
+	snPuback := snPkts1.NewPuback(t.topicID, snPkts1.RC_ACCEPTED)
 	snPuback.SetMessageID(mqPuback.MessageID)
 	t.Success()
 	return t.handler.snSend(snPuback)

--- a/gateway/client_publish_qos1_transaction.go
+++ b/gateway/client_publish_qos1_transaction.go
@@ -21,7 +21,8 @@ import (
 	"context"
 	"fmt"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -51,7 +52,7 @@ func newClientPublishQOS1Transaction(ctx context.Context, h *handler, msgID uint
 	}
 }
 
-func (t *clientPublishQOS1Transaction) Puback(mqPuback *mqttPackets.PubackPacket) error {
+func (t *clientPublishQOS1Transaction) Puback(mqPuback *mqPkts.PubackPacket) error {
 	// MQTT-SN PUBACK packet contains ReturnCode field. MQTT PUBACK packet
 	// does not contain it - PUBACK's implicit meaning is "accepted".
 	// See MQTT-SN specification v. 1.2, chapter 5.4.13.

--- a/gateway/connect_transaction.go
+++ b/gateway/connect_transaction.go
@@ -12,7 +12,8 @@ import (
 	"errors"
 	"fmt"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -25,11 +26,11 @@ type connectTransaction struct {
 	handler       *handler
 	log           util.Logger
 	authEnabled   bool
-	mqConnect     *mqttPackets.ConnectPacket
+	mqConnect     *mqPkts.ConnectPacket
 	authenticated bool
 }
 
-func newConnectTransaction(ctx context.Context, h *handler, authEnabled bool, mqConnect *mqttPackets.ConnectPacket) *connectTransaction {
+func newConnectTransaction(ctx context.Context, h *handler, authEnabled bool, mqConnect *mqPkts.ConnectPacket) *connectTransaction {
 	tLog := h.log.WithTag("CONNECT")
 	tLog.Debug("Created.")
 	return &connectTransaction{
@@ -124,14 +125,14 @@ func (t *connectTransaction) WillMsg(snWillMsg *snPkts1.WillMsg) error {
 	return t.handler.mqttSend(t.mqConnect)
 }
 
-func (t *connectTransaction) Connack(mqConnack *mqttPackets.ConnackPacket) error {
-	if mqConnack.ReturnCode != mqttPackets.Accepted {
+func (t *connectTransaction) Connack(mqConnack *mqPkts.ConnackPacket) error {
+	if mqConnack.ReturnCode != mqPkts.Accepted {
 		// We misuse RC_CONGESTION here because MQTT-SN spec v. 1.2 does not define
 		// any suitable return code.
 		if err := t.SendConnack(snPkts1.RC_CONGESTION); err != nil {
 			return err
 		}
-		returnCodeStr, ok := mqttPackets.ConnackReturnCodes[mqConnack.ReturnCode]
+		returnCodeStr, ok := mqPkts.ConnackReturnCodes[mqConnack.ReturnCode]
 		if !ok {
 			returnCodeStr = "unknown code!"
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -11,11 +11,12 @@ import (
 	"net"
 	"time"
 
-	"github.com/energomonitor/bisquitt/topics"
-	"github.com/energomonitor/bisquitt/util"
 	"github.com/pion/dtls/v2"
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
 	"github.com/pion/udp"
+
+	"github.com/energomonitor/bisquitt/topics"
+	"github.com/energomonitor/bisquitt/util"
 )
 
 type GatewayConfig struct {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -13,10 +13,11 @@ import (
 	"time"
 
 	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+	"github.com/stretchr/testify/assert"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +47,7 @@ func TestRepeatedConnect(t *testing.T) {
 	defer stp.cancel()
 
 	// client --CONNECT--> GW
-	snConnect := snPkts.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker
@@ -58,7 +58,7 @@ func TestRepeatedConnect(t *testing.T) {
 	assert.Equal(byte(4), mqttConnect.ProtocolVersion)
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
-	transaction1, ok := stp.handler.transactions.GetByType(snPkts.CONNECT)
+	transaction1, ok := stp.handler.transactions.GetByType(snPkts1.CONNECT)
 	assert.True(ok)
 
 	// Test transaction1 will be cancelled
@@ -86,7 +86,7 @@ func TestRepeatedConnect(t *testing.T) {
 	assert.Equal(byte(4), mqttConnect.ProtocolVersion)
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
-	transaction2, ok := stp.handler.transactions.GetByType(snPkts.CONNECT)
+	transaction2, ok := stp.handler.transactions.GetByType(snPkts1.CONNECT)
 	assert.True(ok)
 	assert.NotEqual(transaction1, transaction2)
 
@@ -99,8 +99,8 @@ func TestRepeatedConnect(t *testing.T) {
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
-	snConnack := stp.snRecv().(*snPkts.Connack)
-	assert.Equal(snPkts.RC_ACCEPTED, snConnack.ReturnCode)
+	snConnack := stp.snRecv().(*snPkts1.Connack)
+	assert.Equal(snPkts1.RC_ACCEPTED, snConnack.ReturnCode)
 
 	assert.Equal(util.StateActive, stp.handler.state.Get())
 
@@ -129,7 +129,7 @@ func TestPubSubPredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts.NewSubscribe(topicID, snPkts.TIT_PREDEFINED, nil, 0, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, nil, 0, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -146,16 +146,16 @@ func TestPubSubPredefined(t *testing.T) {
 	stp.mqttSend(mqttSuback, false)
 
 	// client <--SUBACK-- GW
-	snSuback := stp.snRecv().(*snPkts.Suback)
+	snSuback := stp.snRecv().(*snPkts1.Suback)
 	assert.Equal(snSubscribe.MessageID(), snSuback.MessageID())
-	assert.Equal(snPkts.RC_ACCEPTED, snSuback.ReturnCode)
+	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 
 	// PUBLISH QOS 0, PREDEFINED TOPIC
 
 	payload := []byte("test-msg-1")
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_PREDEFINED, payload, 0, false, false)
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_PREDEFINED, payload, 0, false, false)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -170,9 +170,9 @@ func TestPubSubPredefined(t *testing.T) {
 	stp.mqttSend(mqttPublish, true)
 
 	// client <--PUBLISH-- GW
-	snPublish = stp.snRecv().(*snPkts.Publish)
+	snPublish = stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_PREDEFINED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_PREDEFINED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 
 	// DISCONNECT
@@ -200,7 +200,7 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts.NewSubscribe(topicID, snPkts.TIT_PREDEFINED, nil, 0, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, nil, 0, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -217,9 +217,9 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	stp.mqttSend(mqttSuback, false)
 
 	// client <--SUBACK-- GW
-	snSuback := stp.snRecv().(*snPkts.Suback)
+	snSuback := stp.snRecv().(*snPkts1.Suback)
 	assert.Equal(snSubscribe.MessageID(), snSuback.MessageID())
-	assert.Equal(snPkts.RC_ACCEPTED, snSuback.ReturnCode)
+	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 
 	// PUBLISH QOS 0, PREDEFINED TOPIC
 
@@ -232,7 +232,7 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	}
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_PREDEFINED, payload, 0, false, false)
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_PREDEFINED, payload, 0, false, false)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -247,9 +247,9 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	stp.mqttSend(mqttPublish, true)
 
 	// client <--PUBLISH-- GW
-	snPublish = stp.snRecv().(*snPkts.Publish)
+	snPublish = stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_PREDEFINED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_PREDEFINED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 
 	// DISCONNECT
@@ -263,7 +263,7 @@ func TestDisconnectedRegister(t *testing.T) {
 	defer stp.cancel()
 
 	stp.snSend(
-		snPkts.NewRegister(0, "test-topic-0"),
+		snPkts1.NewRegister(0, "test-topic-0"),
 		true,
 	)
 
@@ -277,7 +277,7 @@ func TestDisconnectedSubscribe(t *testing.T) {
 	defer stp.cancel()
 
 	stp.snSend(
-		snPkts.NewSubscribe(0, snPkts.TIT_STRING,
+		snPkts1.NewSubscribe(0, snPkts1.TIT_STRING,
 			[]byte("test-topic-0"), 0, false),
 		true,
 	)
@@ -291,9 +291,9 @@ func TestDisconnectedPublishQOS0(t *testing.T) {
 	stp := newTestSetup(t, false, topics.PredefinedTopics{})
 	defer stp.cancel()
 
-	snPublish := snPkts.NewPublish(
-		snPkts.EncodeShortTopic("ab"),
-		snPkts.TIT_SHORT, []byte("test-payload"), 0, false, false,
+	snPublish := snPkts1.NewPublish(
+		snPkts1.EncodeShortTopic("ab"),
+		snPkts1.TIT_SHORT, []byte("test-payload"), 0, false, false,
 	)
 	stp.snSend(snPublish, true)
 
@@ -306,8 +306,8 @@ func TestDisconnectedPublishQOS3Registered(t *testing.T) {
 	stp := newTestSetup(t, false, topics.PredefinedTopics{})
 	defer stp.cancel()
 
-	snPublish := snPkts.NewPublish(
-		123, snPkts.TIT_REGISTERED, []byte("test-payload"), 3, false, false)
+	snPublish := snPkts1.NewPublish(
+		123, snPkts1.TIT_REGISTERED, []byte("test-payload"), 3, false, false)
 	stp.snSend(snPublish, true)
 
 	stp.assertHandlerDone()
@@ -320,11 +320,11 @@ func TestDisconnectedAuthPublishQOS3Registered(t *testing.T) {
 	defer stp.cancel()
 
 	topic := "ab"
-	topicID := snPkts.EncodeShortTopic(topic)
+	topicID := snPkts1.EncodeShortTopic(topic)
 	payload := []byte("test-msg-0")
 	qos := uint8(3)
 
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_SHORT,
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_SHORT,
 		payload, qos, false, false)
 	stp.snSend(snPublish, true)
 
@@ -340,12 +340,12 @@ func TestDisconnectedPublishQOS3Short(t *testing.T) {
 	defer stp.cancel()
 
 	topic := "ab"
-	topicID := snPkts.EncodeShortTopic(topic)
+	topicID := snPkts1.EncodeShortTopic(topic)
 	payload := []byte("test-msg-0")
 	qos := uint8(3)
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_SHORT,
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_SHORT,
 		payload, qos, false, false)
 	stp.snSend(snPublish, true)
 
@@ -377,7 +377,7 @@ func TestDisconnectedPublishQOS3Predefined(t *testing.T) {
 	defer stp.cancel()
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_PREDEFINED,
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_PREDEFINED,
 		payload, qos, false, false)
 	stp.snSend(snPublish, true)
 
@@ -405,7 +405,7 @@ func TestClientPublishQOS0(t *testing.T) {
 	topicID := stp.register(topic)
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_REGISTERED, payload, 0, false, false)
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_REGISTERED, payload, 0, false, false)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -435,7 +435,7 @@ func TestClientPublishQOS1(t *testing.T) {
 	payload = []byte("test-msg-1")
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_REGISTERED, payload, 1, false, false)
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_REGISTERED, payload, 1, false, false)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -451,7 +451,7 @@ func TestClientPublishQOS1(t *testing.T) {
 	stp.mqttSend(mqttPuback, false)
 
 	// client <--PUBACK-- GW
-	snPuback := stp.snRecv().(*snPkts.Puback)
+	snPuback := stp.snRecv().(*snPkts1.Puback)
 	assert.Equal(snPublish.MessageID(), snPuback.MessageID())
 
 	// DISCONNECT
@@ -474,7 +474,7 @@ func TestClientPublishQOS2(t *testing.T) {
 	payload = []byte("test-msg-2")
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts.NewPublish(topicID, snPkts.TIT_REGISTERED, payload, 2, false, false)
+	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_REGISTERED, payload, 2, false, false)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -490,11 +490,11 @@ func TestClientPublishQOS2(t *testing.T) {
 	stp.mqttSend(mqttPubrec, false)
 
 	// client <--PUBREC-- GW
-	snPubrec := stp.snRecv().(*snPkts.Pubrec)
+	snPubrec := stp.snRecv().(*snPkts1.Pubrec)
 	assert.Equal(snPublish.MessageID(), snPubrec.MessageID())
 
 	// client --PUBREL--> GW
-	snPubrel := snPkts.NewPubrel()
+	snPubrel := snPkts1.NewPubrel()
 	snPubrel.SetMessageID(mqttPublish.MessageID)
 	stp.snSend(snPubrel, false)
 
@@ -532,21 +532,21 @@ func TestSubscribeQOS0Wildcard(t *testing.T) {
 	stp.mqttSend(mqttPublish, true)
 
 	// client <--REGISTER-- GW
-	snRegister := stp.snRecv().(*snPkts.Register)
+	snRegister := stp.snRecv().(*snPkts1.Register)
 	assert.Equal(topic, snRegister.TopicName)
-	assert.GreaterOrEqual(snRegister.MessageID(), snPkts.MinMessageID)
-	assert.LessOrEqual(snRegister.MessageID(), snPkts.MaxMessageID)
+	assert.GreaterOrEqual(snRegister.MessageID(), snPkts1.MinMessageID)
+	assert.LessOrEqual(snRegister.MessageID(), snPkts1.MaxMessageID)
 	topicID := snRegister.TopicID
 
 	// client --REGACK--> GW
-	snRegack := snPkts.NewRegack(topicID, snPkts.RC_ACCEPTED)
+	snRegack := snPkts1.NewRegack(topicID, snPkts1.RC_ACCEPTED)
 	snRegack.SetMessageID(snRegister.MessageID())
 	stp.snSend(snRegack, false)
 
 	// client <--PUBLISH-- GW
-	snPublish := stp.snRecv().(*snPkts.Publish)
+	snPublish := stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 	assert.Equal(qos, snPublish.QOS)
 	assert.Equal(false, snPublish.DUP())
@@ -580,9 +580,9 @@ func TestSubscribeQOS1(t *testing.T) {
 	stp.mqttSend(mqttPublish, true)
 
 	// client <--PUBLISH-- GW
-	snPublish := stp.snRecv().(*snPkts.Publish)
+	snPublish := stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 	assert.Equal(qos, snPublish.QOS)
 	assert.Equal(false, snPublish.DUP())
@@ -592,16 +592,16 @@ func TestSubscribeQOS1(t *testing.T) {
 		// (lost: client --PUBACK--> GW)
 
 		// resend: client <--PUBLISH-- GW
-		snPublish = stp.snRecv().(*snPkts.Publish)
+		snPublish = stp.snRecv().(*snPkts1.Publish)
 		assert.Equal(topicID, snPublish.TopicID)
-		assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+		assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 		assert.Equal(payload, snPublish.Data)
 		assert.Equal(qos, snPublish.QOS)
 		assert.Equal(true, snPublish.DUP())
 	}
 
 	// client --PUBACK--> GW
-	snPuback := snPkts.NewPuback(snPublish.TopicID, snPkts.RC_ACCEPTED)
+	snPuback := snPkts1.NewPuback(snPublish.TopicID, snPkts1.RC_ACCEPTED)
 	snPuback.SetMessageID(snPublish.MessageID())
 	stp.snSend(snPuback, false)
 
@@ -642,19 +642,19 @@ func TestSubscribeQOS1Wildcard(t *testing.T) {
 	stp.mqttSend(mqttPublish, true)
 
 	// client <--REGISTER-- GW
-	snRegister := stp.snRecv().(*snPkts.Register)
+	snRegister := stp.snRecv().(*snPkts1.Register)
 	assert.Equal(topic, snRegister.TopicName)
 	topicID := snRegister.TopicID
 
 	// client --REGACK--> GW
-	snRegack := snPkts.NewRegack(topicID, snPkts.RC_ACCEPTED)
+	snRegack := snPkts1.NewRegack(topicID, snPkts1.RC_ACCEPTED)
 	snRegack.SetMessageID(snRegister.MessageID())
 	stp.snSend(snRegack, false)
 
 	// client <--PUBLISH-- GW
-	snPublish := stp.snRecv().(*snPkts.Publish)
+	snPublish := stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 	assert.Equal(qos, snPublish.QOS)
 	assert.Equal(false, snPublish.DUP())
@@ -664,16 +664,16 @@ func TestSubscribeQOS1Wildcard(t *testing.T) {
 		// (lost: client --PUBACK--> GW)
 
 		// resend: client <--PUBLISH-- GW
-		snPublish = stp.snRecv().(*snPkts.Publish)
+		snPublish = stp.snRecv().(*snPkts1.Publish)
 		assert.Equal(topicID, snPublish.TopicID)
-		assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+		assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 		assert.Equal(payload, snPublish.Data)
 		assert.Equal(qos, snPublish.QOS)
 		assert.Equal(true, snPublish.DUP())
 	}
 
 	// client --PUBACK--> GW
-	snPuback := snPkts.NewPuback(snPublish.TopicID, snPkts.RC_ACCEPTED)
+	snPuback := snPkts1.NewPuback(snPublish.TopicID, snPkts1.RC_ACCEPTED)
 	snPuback.SetMessageID(snPublish.MessageID())
 	stp.snSend(snPuback, false)
 
@@ -714,9 +714,9 @@ func TestSubscribeQOS2(t *testing.T) {
 	msgID := mqttPublish.MessageID
 
 	// client <--PUBLISH-- GW
-	snPublish := stp.snRecv().(*snPkts.Publish)
+	snPublish := stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 	assert.Equal(qos, snPublish.QOS)
 	assert.Equal(msgID, snPublish.MessageID())
@@ -726,9 +726,9 @@ func TestSubscribeQOS2(t *testing.T) {
 		// (lost: client --PUBREC--> GW)
 
 		// resend: client <--PUBLISH-- GW
-		snPublish := stp.snRecv().(*snPkts.Publish)
+		snPublish := stp.snRecv().(*snPkts1.Publish)
 		assert.Equal(topicID, snPublish.TopicID)
-		assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+		assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 		assert.Equal(payload, snPublish.Data)
 		assert.Equal(qos, snPublish.QOS)
 		assert.Equal(msgID, snPublish.MessageID())
@@ -736,7 +736,7 @@ func TestSubscribeQOS2(t *testing.T) {
 	}
 
 	// client --PUBREC--> GW
-	snPubrec := snPkts.NewPubrec()
+	snPubrec := snPkts1.NewPubrec()
 	snPubrec.SetMessageID(msgID)
 	stp.snSend(snPubrec, false)
 
@@ -755,7 +755,7 @@ func TestSubscribeQOS2(t *testing.T) {
 	stp.mqttSend(mqttPubrel, false)
 
 	// client <--PUBREL-- GW
-	snPubrel := stp.snRecv().(*snPkts.Pubrel)
+	snPubrel := stp.snRecv().(*snPkts1.Pubrel)
 	assert.Equal(msgID, snPubrel.MessageID())
 
 	// Two lost PUBCOMPs => two PUBREL resends
@@ -763,12 +763,12 @@ func TestSubscribeQOS2(t *testing.T) {
 		// (lost: client --PUBCOMP--> GW)
 
 		// resend: client <--PUBREL-- GW
-		snPubrel := stp.snRecv().(*snPkts.Pubrel)
+		snPubrel := stp.snRecv().(*snPkts1.Pubrel)
 		assert.Equal(msgID, snPubrel.MessageID())
 	}
 
 	// client --PUBCOMP--> GW
-	snPubcomp := snPkts.NewPubcomp()
+	snPubcomp := snPkts1.NewPubcomp()
 	snPubcomp.SetMessageID(msgID)
 	stp.snSend(snPubcomp, false)
 
@@ -807,19 +807,19 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 	msgID := mqttPublish.MessageID
 
 	// client <--REGISTER-- GW
-	snRegister := stp.snRecv().(*snPkts.Register)
+	snRegister := stp.snRecv().(*snPkts1.Register)
 	assert.Equal(topic, snRegister.TopicName)
 	topicID := snRegister.TopicID
 
 	// client --REGACK--> GW
-	snRegack := snPkts.NewRegack(topicID, snPkts.RC_ACCEPTED)
+	snRegack := snPkts1.NewRegack(topicID, snPkts1.RC_ACCEPTED)
 	snRegack.SetMessageID(snRegister.MessageID())
 	stp.snSend(snRegack, false)
 
 	// client <--PUBLISH-- GW
-	snPublish := stp.snRecv().(*snPkts.Publish)
+	snPublish := stp.snRecv().(*snPkts1.Publish)
 	assert.Equal(topicID, snPublish.TopicID)
-	assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+	assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 	assert.Equal(payload, snPublish.Data)
 	assert.Equal(qos, snPublish.QOS)
 	assert.Equal(msgID, snPublish.MessageID())
@@ -829,9 +829,9 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 		// (lost: client --PUBREC--> GW)
 
 		// resend: client <--PUBLISH-- GW
-		snPublish := stp.snRecv().(*snPkts.Publish)
+		snPublish := stp.snRecv().(*snPkts1.Publish)
 		assert.Equal(topicID, snPublish.TopicID)
-		assert.Equal(snPkts.TIT_REGISTERED, snPublish.TopicIDType)
+		assert.Equal(snPkts1.TIT_REGISTERED, snPublish.TopicIDType)
 		assert.Equal(payload, snPublish.Data)
 		assert.Equal(qos, snPublish.QOS)
 		assert.Equal(msgID, snPublish.MessageID())
@@ -839,7 +839,7 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 	}
 
 	// client --PUBREC--> GW
-	snPubrec := snPkts.NewPubrec()
+	snPubrec := snPkts1.NewPubrec()
 	snPubrec.SetMessageID(msgID)
 	stp.snSend(snPubrec, false)
 
@@ -858,7 +858,7 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 	stp.mqttSend(mqttPubrel, false)
 
 	// client <--PUBREL-- GW
-	snPubrel := stp.snRecv().(*snPkts.Pubrel)
+	snPubrel := stp.snRecv().(*snPkts1.Pubrel)
 	assert.Equal(msgID, snPubrel.MessageID())
 
 	// Two lost PUBCOMPs => two PUBREL resends
@@ -866,12 +866,12 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 		// (lost: client --PUBCOMP--> GW)
 
 		// resend: client <--PUBREL-- GW
-		snPubrel := stp.snRecv().(*snPkts.Pubrel)
+		snPubrel := stp.snRecv().(*snPkts1.Pubrel)
 		assert.Equal(msgID, snPubrel.MessageID())
 	}
 
 	// client --PUBCOMP--> GW
-	snPubcomp := snPkts.NewPubcomp()
+	snPubcomp := snPkts1.NewPubcomp()
 	snPubcomp.SetMessageID(msgID)
 	stp.snSend(snPubcomp, false)
 
@@ -896,7 +896,7 @@ func TestUnsubscribeString(t *testing.T) {
 	stp.subscribe(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts.NewUnsubscribe(0, snPkts.TIT_STRING, []byte(topic))
+	snUnsubscribe := snPkts1.NewUnsubscribe(0, snPkts1.TIT_STRING, []byte(topic))
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -910,7 +910,7 @@ func TestUnsubscribeString(t *testing.T) {
 	stp.mqttSend(mqttUnsuback, false)
 
 	// client <--UNSUBACK-- GW
-	snUnsuback := stp.snRecv().(*snPkts.Unsuback)
+	snUnsuback := stp.snRecv().(*snPkts1.Unsuback)
 	assert.Equal(snUnsubscribe.MessageID(), snUnsuback.MessageID())
 
 	// DISCONNECT
@@ -930,7 +930,7 @@ func TestUnsubscribeShort(t *testing.T) {
 	stp.subscribeShort(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts.NewUnsubscribe(snPkts.EncodeShortTopic(topic), snPkts.TIT_SHORT, []byte(""))
+	snUnsubscribe := snPkts1.NewUnsubscribe(snPkts1.EncodeShortTopic(topic), snPkts1.TIT_SHORT, []byte(""))
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -944,7 +944,7 @@ func TestUnsubscribeShort(t *testing.T) {
 	stp.mqttSend(mqttUnsuback, false)
 
 	// client <--UNSUBACK-- GW
-	snUnsuback := stp.snRecv().(*snPkts.Unsuback)
+	snUnsuback := stp.snRecv().(*snPkts1.Unsuback)
 	assert.Equal(snUnsubscribe.MessageID(), snUnsuback.MessageID())
 
 	// DISCONNECT
@@ -971,7 +971,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts.NewSubscribe(topicID, snPkts.TIT_PREDEFINED, nil, 0, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, nil, 0, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -988,12 +988,12 @@ func TestUnsubscribePredefined(t *testing.T) {
 	stp.mqttSend(mqttSuback, false)
 
 	// client <--SUBACK-- GW
-	snSuback := stp.snRecv().(*snPkts.Suback)
+	snSuback := stp.snRecv().(*snPkts1.Suback)
 	assert.Equal(snSubscribe.MessageID(), snSuback.MessageID())
-	assert.Equal(snPkts.RC_ACCEPTED, snSuback.ReturnCode)
+	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts.NewUnsubscribe(topicID, snPkts.TIT_PREDEFINED, []byte(""))
+	snUnsubscribe := snPkts1.NewUnsubscribe(topicID, snPkts1.TIT_PREDEFINED, []byte(""))
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -1007,7 +1007,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 	stp.mqttSend(mqttUnsuback, false)
 
 	// client <--UNSUBACK-- GW
-	snUnsuback := stp.snRecv().(*snPkts.Unsuback)
+	snUnsuback := stp.snRecv().(*snPkts1.Unsuback)
 	assert.Equal(snUnsubscribe.MessageID(), snUnsuback.MessageID())
 
 	// DISCONNECT
@@ -1030,23 +1030,23 @@ func TestLastWill(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts.NewConnect(clientID, true, true, keepalive)
+	snConnect := snPkts1.NewConnect(clientID, true, true, keepalive)
 	stp.snSend(snConnect, false)
 
 	// client <--WILLTOPICREQ-- GW
-	_, ok := stp.snRecv().(*snPkts.WillTopicReq)
+	_, ok := stp.snRecv().(*snPkts1.WillTopicReq)
 	assert.True(ok)
 
 	// client --CONNECT--> GW
-	snWillTopic := snPkts.NewWillTopic(willTopic, willQos, willRetain)
+	snWillTopic := snPkts1.NewWillTopic(willTopic, willQos, willRetain)
 	stp.snSend(snWillTopic, false)
 
 	// client <--WILLMSGREQ-- GW
-	_, ok = stp.snRecv().(*snPkts.WillMsgReq)
+	_, ok = stp.snRecv().(*snPkts1.WillMsgReq)
 	assert.True(ok)
 
 	// client --CONNECT--> GW
-	snWillMsg := snPkts.NewWillMsg(willPayload)
+	snWillMsg := snPkts1.NewWillMsg(willPayload)
 	stp.snSend(snWillMsg, false)
 
 	// GW --CONNECT--> MQTT broker
@@ -1063,8 +1063,8 @@ func TestLastWill(t *testing.T) {
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
-	snConnack := stp.snRecv().(*snPkts.Connack)
-	assert.Equal(snPkts.RC_ACCEPTED, snConnack.ReturnCode)
+	snConnack := stp.snRecv().(*snPkts1.Connack)
+	assert.Equal(snPkts1.RC_ACCEPTED, snConnack.ReturnCode)
 
 	assert.Equal(util.StateActive, stp.handler.state.Get())
 
@@ -1079,7 +1079,7 @@ func TestLastWill(t *testing.T) {
 
 	// NOTE: It is unclean if the gateway should send DISCONNECT here or not.
 	// client <--DISCONNECT-- GW
-	snDisconnectReply := stp.snRecv().(*snPkts.Disconnect)
+	snDisconnectReply := stp.snRecv().(*snPkts1.Disconnect)
 	assert.Equal(uint16(0), snDisconnectReply.Duration)
 
 	wg := &sync.WaitGroup{}
@@ -1110,11 +1110,11 @@ func TestConnectTimeout(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts.NewConnect(clientID, true, true, 2)
+	snConnect := snPkts1.NewConnect(clientID, true, true, 2)
 	stp.snSend(snConnect, false)
 
 	// client <--WILLTOPICREQ-- GW
-	_, ok := stp.snRecv().(*snPkts.WillTopicReq)
+	_, ok := stp.snRecv().(*snPkts1.WillTopicReq)
 	assert.True(ok)
 
 	// A malicious client does not continue the transaction.
@@ -1137,11 +1137,11 @@ func TestAuthSuccess(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
 	stp.snSend(snConnect, false)
 
 	// client --AUTH--> GW
-	snAuth := snPkts.NewAuthPlain(user, password)
+	snAuth := snPkts1.NewAuthPlain(user, password)
 	stp.snSend(snAuth, false)
 
 	// GW --CONNECT--> MQTT broker
@@ -1162,8 +1162,8 @@ func TestAuthSuccess(t *testing.T) {
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
-	snConnack := stp.snRecv().(*snPkts.Connack)
-	assert.Equal(snPkts.RC_ACCEPTED, snConnack.ReturnCode)
+	snConnack := stp.snRecv().(*snPkts1.Connack)
+	assert.Equal(snPkts1.RC_ACCEPTED, snConnack.ReturnCode)
 
 	assert.Equal(util.StateActive, stp.handler.state.Get())
 }
@@ -1181,11 +1181,11 @@ func TestAuthFail(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
 	stp.snSend(snConnect, false)
 
 	// client --AUTH--> GW
-	snAuth := snPkts.NewAuthPlain(user, password)
+	snAuth := snPkts1.NewAuthPlain(user, password)
 	stp.snSend(snAuth, false)
 
 	// GW --CONNECT--> MQTT broker
@@ -1206,8 +1206,8 @@ func TestAuthFail(t *testing.T) {
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
-	snConnack := stp.snRecv().(*snPkts.Connack)
-	assert.Equal(snPkts.RC_CONGESTION, snConnack.ReturnCode)
+	snConnack := stp.snRecv().(*snPkts1.Connack)
+	assert.Equal(snPkts1.RC_CONGESTION, snConnack.ReturnCode)
 
 	assert.Equal(util.StateDisconnected, stp.handler.state.Get())
 }
@@ -1312,9 +1312,9 @@ func (stp *testSetup) createSocketPair(sockType string) (*net.UnixListener, *net
 	return listener, conn
 }
 
-func (stp *testSetup) snSend(pkt snPkts.Packet, setMsgID bool) {
+func (stp *testSetup) snSend(pkt snPkts1.Packet, setMsgID bool) {
 	if setMsgID {
-		if pkt2, ok := pkt.(snPkts.PacketWithID); ok {
+		if pkt2, ok := pkt.(snPkts1.PacketWithID); ok {
 			pkt2.SetMessageID(stp.snNextMsgID)
 			stp.snNextMsgID++
 		}
@@ -1326,7 +1326,7 @@ func (stp *testSetup) snSend(pkt snPkts.Packet, setMsgID bool) {
 	}
 }
 
-func (stp *testSetup) snRecv() snPkts.Packet {
+func (stp *testSetup) snRecv() snPkts1.Packet {
 	buff := make([]byte, maxTestPktLength)
 	n, err := stp.snConn.Read(buff)
 	if err != nil {
@@ -1336,9 +1336,9 @@ func (stp *testSetup) snRecv() snPkts.Packet {
 	}
 
 	pktReader := bytes.NewReader(buff[:n])
-	header := &snPkts.Header{}
+	header := &snPkts1.Header{}
 	header.Unpack(pktReader)
-	pkt := snPkts.NewPacketWithHeader(*header)
+	pkt := snPkts1.NewPacketWithHeader(*header)
 	pkt.Unpack(pktReader)
 
 	return pkt
@@ -1454,7 +1454,7 @@ func (stp *testSetup) connect() {
 	clientID := []byte("test-client")
 
 	// client --CONNECT--> GW
-	snConnect := snPkts.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker
@@ -1471,8 +1471,8 @@ func (stp *testSetup) connect() {
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
-	snConnack := stp.snRecv().(*snPkts.Connack)
-	assert.Equal(snPkts.RC_ACCEPTED, snConnack.ReturnCode)
+	snConnack := stp.snRecv().(*snPkts1.Connack)
+	assert.Equal(snPkts1.RC_ACCEPTED, snConnack.ReturnCode)
 
 	assert.Equal(util.StateActive, stp.handler.state.Get())
 }
@@ -1482,13 +1482,13 @@ func (stp *testSetup) register(topic string) uint16 {
 	assert := assert.New(stp.t)
 
 	// client --REGISTER--> GW
-	snRegister := snPkts.NewRegister(0, topic)
+	snRegister := snPkts1.NewRegister(0, topic)
 	snRegister.TopicName = topic
 	stp.snSend(snRegister, true)
 
 	// client <--REGACK-- GW
-	snRegack := stp.snRecv().(*snPkts.Regack)
-	assert.Equal(snPkts.RC_ACCEPTED, snRegack.ReturnCode)
+	snRegack := stp.snRecv().(*snPkts1.Regack)
+	assert.Equal(snPkts1.RC_ACCEPTED, snRegack.ReturnCode)
 	assert.Equal(snRegister.MessageID(), snRegack.MessageID())
 	assert.Greater(snRegack.TopicID, uint16(0))
 
@@ -1500,7 +1500,7 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	assert := assert.New(stp.t)
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts.NewSubscribe(0, snPkts.TIT_STRING, []byte(topic), qos, false)
+	snSubscribe := snPkts1.NewSubscribe(0, snPkts1.TIT_STRING, []byte(topic), qos, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -1517,14 +1517,14 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	stp.mqttSend(mqttSuback, false)
 
 	// client <--SUBACK-- GW
-	snSuback := stp.snRecv().(*snPkts.Suback)
+	snSuback := stp.snRecv().(*snPkts1.Suback)
 	assert.Equal(snSubscribe.MessageID(), snSuback.MessageID())
-	assert.Equal(snPkts.RC_ACCEPTED, snSuback.ReturnCode)
+	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 	if hasWildcard(topic) {
 		assert.Equal(uint16(0), snSuback.TopicID)
 	} else {
-		assert.GreaterOrEqual(snSuback.TopicID, snPkts.MinTopicID)
-		assert.LessOrEqual(snSuback.TopicID, snPkts.MaxTopicID)
+		assert.GreaterOrEqual(snSuback.TopicID, snPkts1.MinTopicID)
+		assert.LessOrEqual(snSuback.TopicID, snPkts1.MaxTopicID)
 	}
 
 	return snSuback.TopicID
@@ -1533,11 +1533,11 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 	assert := assert.New(stp.t)
 
-	assert.True(snPkts.IsShortTopic(topic))
+	assert.True(snPkts1.IsShortTopic(topic))
 
 	// client --SUBSCRIBE--> GW
-	topicID := snPkts.EncodeShortTopic(topic)
-	snSubscribe := snPkts.NewSubscribe(topicID, snPkts.TIT_SHORT, nil, qos, false)
+	topicID := snPkts1.EncodeShortTopic(topic)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_SHORT, nil, qos, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -1554,9 +1554,9 @@ func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 	stp.mqttSend(mqttSuback, false)
 
 	// client <--SUBACK-- GW
-	snSuback := stp.snRecv().(*snPkts.Suback)
+	snSuback := stp.snRecv().(*snPkts1.Suback)
 	assert.Equal(snSubscribe.MessageID(), snSuback.MessageID())
-	assert.Equal(snPkts.RC_ACCEPTED, snSuback.ReturnCode)
+	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 	assert.Equal(snSuback.TopicID, uint16(0))
 }
 
@@ -1565,7 +1565,7 @@ func (stp *testSetup) disconnect() {
 	assert := assert.New(stp.t)
 
 	// client --DISCONNECT--> GW
-	snDisconnect := snPkts.NewDisconnect(0)
+	snDisconnect := snPkts1.NewDisconnect(0)
 	stp.snSend(snDisconnect, true)
 
 	// GW --DISCONNECT--> MQTT broker
@@ -1573,7 +1573,7 @@ func (stp *testSetup) disconnect() {
 	assert.Equal(uint8(mqttPackets.Disconnect), mqttDisconnect.MessageType)
 
 	// client <--DISCONNECT-- GW
-	snDisconnectReply := stp.snRecv().(*snPkts.Disconnect)
+	snDisconnectReply := stp.snRecv().(*snPkts1.Disconnect)
 	assert.Equal(uint16(0), snDisconnectReply.Duration)
 
 	stp.assertHandlerDone()

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
@@ -51,7 +51,7 @@ func TestRepeatedConnect(t *testing.T) {
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker
-	mqttConnect := stp.mqttRecv().(*mqttPackets.ConnectPacket)
+	mqttConnect := stp.mqttRecv().(*mqPkts.ConnectPacket)
 	assert.Equal(string(snConnect.ClientID), mqttConnect.ClientIdentifier)
 	assert.Equal(snConnect.CleanSession, mqttConnect.CleanSession)
 	assert.Equal(snConnect.Duration, mqttConnect.Keepalive)
@@ -79,7 +79,7 @@ func TestRepeatedConnect(t *testing.T) {
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker
-	mqttConnect = stp.mqttRecv().(*mqttPackets.ConnectPacket)
+	mqttConnect = stp.mqttRecv().(*mqPkts.ConnectPacket)
 	assert.Equal(string(snConnect.ClientID), mqttConnect.ClientIdentifier)
 	assert.Equal(snConnect.CleanSession, mqttConnect.CleanSession)
 	assert.Equal(snConnect.Duration, mqttConnect.Keepalive)
@@ -94,8 +94,8 @@ func TestRepeatedConnect(t *testing.T) {
 	wg.Wait()
 
 	// GW <--CONNACK-- MQTT broker
-	mqttConnack := mqttPackets.NewControlPacket(mqttPackets.Connack).(*mqttPackets.ConnackPacket)
-	mqttConnack.ReturnCode = mqttPackets.Accepted
+	mqttConnack := mqPkts.NewControlPacket(mqPkts.Connack).(*mqPkts.ConnackPacket)
+	mqttConnack.ReturnCode = mqPkts.Accepted
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
@@ -133,14 +133,14 @@ func TestPubSubPredefined(t *testing.T) {
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
-	mqttSubscribe := stp.mqttRecv().(*mqttPackets.SubscribePacket)
+	mqttSubscribe := stp.mqttRecv().(*mqPkts.SubscribePacket)
 	assert.Len(mqttSubscribe.Qoss, 1)
 	assert.Equal(snSubscribe.QOS, mqttSubscribe.Qoss[0])
 	assert.Len(mqttSubscribe.Topics, 1)
 	assert.Equal(topic, mqttSubscribe.Topics[0])
 
 	// GW <--SUBACK-- MQTT broker
-	mqttSuback := mqttPackets.NewControlPacket(mqttPackets.Suback).(*mqttPackets.SubackPacket)
+	mqttSuback := mqPkts.NewControlPacket(mqPkts.Suback).(*mqPkts.SubackPacket)
 	mqttSuback.MessageID = mqttSubscribe.MessageID
 	mqttSuback.ReturnCodes = []byte{snSubscribe.QOS}
 	stp.mqttSend(mqttSuback, false)
@@ -159,7 +159,7 @@ func TestPubSubPredefined(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.Equal(snPublish.QOS, mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
 	assert.Equal(snPublish.Data, mqttPublish.Payload)
@@ -204,14 +204,14 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
-	mqttSubscribe := stp.mqttRecv().(*mqttPackets.SubscribePacket)
+	mqttSubscribe := stp.mqttRecv().(*mqPkts.SubscribePacket)
 	assert.Len(mqttSubscribe.Qoss, 1)
 	assert.Equal(snSubscribe.QOS, mqttSubscribe.Qoss[0])
 	assert.Len(mqttSubscribe.Topics, 1)
 	assert.Equal(topic, mqttSubscribe.Topics[0])
 
 	// GW <--SUBACK-- MQTT broker
-	mqttSuback := mqttPackets.NewControlPacket(mqttPackets.Suback).(*mqttPackets.SubackPacket)
+	mqttSuback := mqPkts.NewControlPacket(mqPkts.Suback).(*mqPkts.SubackPacket)
 	mqttSuback.MessageID = mqttSubscribe.MessageID
 	mqttSuback.ReturnCodes = []byte{snSubscribe.QOS}
 	stp.mqttSend(mqttSuback, false)
@@ -236,7 +236,7 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.Equal(snPublish.QOS, mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
 	assert.Equal(payload, mqttPublish.Payload)
@@ -350,7 +350,7 @@ func TestDisconnectedPublishQOS3Short(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.Equal(uint8(0), mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
 	assert.Equal(payload, mqttPublish.Payload)
@@ -382,7 +382,7 @@ func TestDisconnectedPublishQOS3Predefined(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.Equal(uint8(0), mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
 	assert.Equal(payload, mqttPublish.Payload)
@@ -409,7 +409,7 @@ func TestClientPublishQOS0(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.Equal(uint16(0), mqttPublish.MessageID)
 	assert.Equal(snPublish.QOS, mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
@@ -439,14 +439,14 @@ func TestClientPublishQOS1(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.NotEqual(mqttNextMsgID, mqttPublish.MessageID)
 	assert.Equal(snPublish.QOS, mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
 	assert.Equal(snPublish.Data, mqttPublish.Payload)
 
 	// GW <--PUBACK-- MQTT broker
-	mqttPuback := mqttPackets.NewControlPacket(mqttPackets.Puback).(*mqttPackets.PubackPacket)
+	mqttPuback := mqPkts.NewControlPacket(mqPkts.Puback).(*mqPkts.PubackPacket)
 	mqttPuback.MessageID = mqttPublish.MessageID
 	stp.mqttSend(mqttPuback, false)
 
@@ -478,14 +478,14 @@ func TestClientPublishQOS2(t *testing.T) {
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
-	mqttPublish := stp.mqttRecv().(*mqttPackets.PublishPacket)
+	mqttPublish := stp.mqttRecv().(*mqPkts.PublishPacket)
 	assert.NotEqual(mqttNextMsgID, mqttPublish.MessageID)
 	assert.Equal(snPublish.QOS, mqttPublish.Qos)
 	assert.Equal(topic, mqttPublish.TopicName)
 	assert.Equal(snPublish.Data, mqttPublish.Payload)
 
 	// GW <--PUBREC-- MQTT broker
-	mqttPubrec := mqttPackets.NewControlPacket(mqttPackets.Pubrec).(*mqttPackets.PubrecPacket)
+	mqttPubrec := mqPkts.NewControlPacket(mqPkts.Pubrec).(*mqPkts.PubrecPacket)
 	mqttPubrec.MessageID = mqttPublish.MessageID
 	stp.mqttSend(mqttPubrec, false)
 
@@ -499,7 +499,7 @@ func TestClientPublishQOS2(t *testing.T) {
 	stp.snSend(snPubrel, false)
 
 	// GW --PUBREL--> MQTT broker
-	mqttPubrel := stp.mqttRecv().(*mqttPackets.PubrelPacket)
+	mqttPubrel := stp.mqttRecv().(*mqPkts.PubrelPacket)
 	assert.Equal(snPublish.MessageID(), mqttPubrel.MessageID)
 
 	// DISCONNECT
@@ -525,7 +525,7 @@ func TestSubscribeQOS0Wildcard(t *testing.T) {
 	qos := uint8(0)
 
 	// GW <--PUBLISH-- MQTT broker
-	mqttPublish := mqttPackets.NewControlPacket(mqttPackets.Publish).(*mqttPackets.PublishPacket)
+	mqttPublish := mqPkts.NewControlPacket(mqPkts.Publish).(*mqPkts.PublishPacket)
 	mqttPublish.Qos = qos
 	mqttPublish.TopicName = topic
 	mqttPublish.Payload = payload
@@ -573,7 +573,7 @@ func TestSubscribeQOS1(t *testing.T) {
 	qos := uint8(1)
 
 	// GW <--PUBLISH-- MQTT broker
-	mqttPublish := mqttPackets.NewControlPacket(mqttPackets.Publish).(*mqttPackets.PublishPacket)
+	mqttPublish := mqPkts.NewControlPacket(mqPkts.Publish).(*mqPkts.PublishPacket)
 	mqttPublish.Qos = qos
 	mqttPublish.TopicName = topic
 	mqttPublish.Payload = payload
@@ -606,7 +606,7 @@ func TestSubscribeQOS1(t *testing.T) {
 	stp.snSend(snPuback, false)
 
 	// GW --PUBACK--> MQTT broker
-	mqttPuback := stp.mqttRecv().(*mqttPackets.PubackPacket)
+	mqttPuback := stp.mqttRecv().(*mqPkts.PubackPacket)
 	assert.Equal(snPuback.MessageID(), mqttPuback.MessageID)
 
 	// No more resends expected...
@@ -635,7 +635,7 @@ func TestSubscribeQOS1Wildcard(t *testing.T) {
 	qos := uint8(1)
 
 	// GW <--PUBLISH-- MQTT broker
-	mqttPublish := mqttPackets.NewControlPacket(mqttPackets.Publish).(*mqttPackets.PublishPacket)
+	mqttPublish := mqPkts.NewControlPacket(mqPkts.Publish).(*mqPkts.PublishPacket)
 	mqttPublish.Qos = qos
 	mqttPublish.TopicName = topic
 	mqttPublish.Payload = payload
@@ -678,7 +678,7 @@ func TestSubscribeQOS1Wildcard(t *testing.T) {
 	stp.snSend(snPuback, false)
 
 	// GW --PUBACK--> MQTT broker
-	mqttPuback := stp.mqttRecv().(*mqttPackets.PubackPacket)
+	mqttPuback := stp.mqttRecv().(*mqPkts.PubackPacket)
 	assert.Equal(snPuback.MessageID(), mqttPuback.MessageID)
 
 	// No more resends expected...
@@ -706,7 +706,7 @@ func TestSubscribeQOS2(t *testing.T) {
 	qos := uint8(2)
 
 	// GW <--PUBLISH-- MQTT broker
-	mqttPublish := mqttPackets.NewControlPacket(mqttPackets.Publish).(*mqttPackets.PublishPacket)
+	mqttPublish := mqPkts.NewControlPacket(mqPkts.Publish).(*mqPkts.PublishPacket)
 	mqttPublish.Qos = qos
 	mqttPublish.TopicName = topic
 	mqttPublish.Payload = payload
@@ -741,16 +741,16 @@ func TestSubscribeQOS2(t *testing.T) {
 	stp.snSend(snPubrec, false)
 
 	// GW --PUBREC--> MQTT broker
-	mqttPubrec := stp.mqttRecv().(*mqttPackets.PubrecPacket)
+	mqttPubrec := stp.mqttRecv().(*mqPkts.PubrecPacket)
 	assert.Equal(msgID, mqttPubrec.MessageID)
 
 	// Lost MQTT PUBREC or PUBREL => MQTT PUBREC resend
 	// GW --PUBREC--> MQTT broker
-	mqttPubrec = stp.mqttRecv().(*mqttPackets.PubrecPacket)
+	mqttPubrec = stp.mqttRecv().(*mqPkts.PubrecPacket)
 	assert.Equal(msgID, mqttPubrec.MessageID)
 
 	// GW <--PUBREL-- MQTT broker
-	mqttPubrel := mqttPackets.NewControlPacket(mqttPackets.Pubrel).(*mqttPackets.PubrelPacket)
+	mqttPubrel := mqPkts.NewControlPacket(mqPkts.Pubrel).(*mqPkts.PubrelPacket)
 	mqttPubrel.MessageID = msgID
 	stp.mqttSend(mqttPubrel, false)
 
@@ -773,7 +773,7 @@ func TestSubscribeQOS2(t *testing.T) {
 	stp.snSend(snPubcomp, false)
 
 	// GW --PUBCOMP--> MQTT broker
-	mqttPubcomp := stp.mqttRecv().(*mqttPackets.PubcompPacket)
+	mqttPubcomp := stp.mqttRecv().(*mqPkts.PubcompPacket)
 	assert.Equal(msgID, mqttPubcomp.MessageID)
 
 	// DISCONNECT
@@ -799,7 +799,7 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 	qos := uint8(2)
 
 	// GW <--PUBLISH-- MQTT broker
-	mqttPublish := mqttPackets.NewControlPacket(mqttPackets.Publish).(*mqttPackets.PublishPacket)
+	mqttPublish := mqPkts.NewControlPacket(mqPkts.Publish).(*mqPkts.PublishPacket)
 	mqttPublish.Qos = qos
 	mqttPublish.TopicName = topic
 	mqttPublish.Payload = payload
@@ -844,16 +844,16 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 	stp.snSend(snPubrec, false)
 
 	// GW --PUBREC--> MQTT broker
-	mqttPubrec := stp.mqttRecv().(*mqttPackets.PubrecPacket)
+	mqttPubrec := stp.mqttRecv().(*mqPkts.PubrecPacket)
 	assert.Equal(msgID, mqttPubrec.MessageID)
 
 	// Lost MQTT PUBREC or PUBREL => MQTT PUBREC resend
 	// GW --PUBREC--> MQTT broker
-	mqttPubrec = stp.mqttRecv().(*mqttPackets.PubrecPacket)
+	mqttPubrec = stp.mqttRecv().(*mqPkts.PubrecPacket)
 	assert.Equal(msgID, mqttPubrec.MessageID)
 
 	// GW <--PUBREL-- MQTT broker
-	mqttPubrel := mqttPackets.NewControlPacket(mqttPackets.Pubrel).(*mqttPackets.PubrelPacket)
+	mqttPubrel := mqPkts.NewControlPacket(mqPkts.Pubrel).(*mqPkts.PubrelPacket)
 	mqttPubrel.MessageID = msgID
 	stp.mqttSend(mqttPubrel, false)
 
@@ -876,7 +876,7 @@ func TestSubscribeQOS2Wildcard(t *testing.T) {
 	stp.snSend(snPubcomp, false)
 
 	// GW --PUBCOMP--> MQTT broker
-	mqttPubcomp := stp.mqttRecv().(*mqttPackets.PubcompPacket)
+	mqttPubcomp := stp.mqttRecv().(*mqPkts.PubcompPacket)
 	assert.Equal(msgID, mqttPubcomp.MessageID)
 
 	// DISCONNECT
@@ -900,12 +900,12 @@ func TestUnsubscribeString(t *testing.T) {
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
-	mqttUnsubscribe := stp.mqttRecv().(*mqttPackets.UnsubscribePacket)
+	mqttUnsubscribe := stp.mqttRecv().(*mqPkts.UnsubscribePacket)
 	assert.Len(mqttUnsubscribe.Topics, 1)
 	assert.Equal(topic, mqttUnsubscribe.Topics[0])
 
 	// GW <--UNSUBACK-- MQTT broker
-	mqttUnsuback := mqttPackets.NewControlPacket(mqttPackets.Unsuback).(*mqttPackets.UnsubackPacket)
+	mqttUnsuback := mqPkts.NewControlPacket(mqPkts.Unsuback).(*mqPkts.UnsubackPacket)
 	mqttUnsuback.MessageID = mqttUnsubscribe.MessageID
 	stp.mqttSend(mqttUnsuback, false)
 
@@ -934,12 +934,12 @@ func TestUnsubscribeShort(t *testing.T) {
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
-	mqttUnsubscribe := stp.mqttRecv().(*mqttPackets.UnsubscribePacket)
+	mqttUnsubscribe := stp.mqttRecv().(*mqPkts.UnsubscribePacket)
 	assert.Len(mqttUnsubscribe.Topics, 1)
 	assert.Equal(topic, mqttUnsubscribe.Topics[0])
 
 	// GW <--UNSUBACK-- MQTT broker
-	mqttUnsuback := mqttPackets.NewControlPacket(mqttPackets.Unsuback).(*mqttPackets.UnsubackPacket)
+	mqttUnsuback := mqPkts.NewControlPacket(mqPkts.Unsuback).(*mqPkts.UnsubackPacket)
 	mqttUnsuback.MessageID = mqttUnsubscribe.MessageID
 	stp.mqttSend(mqttUnsuback, false)
 
@@ -975,14 +975,14 @@ func TestUnsubscribePredefined(t *testing.T) {
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
-	mqttSubscribe := stp.mqttRecv().(*mqttPackets.SubscribePacket)
+	mqttSubscribe := stp.mqttRecv().(*mqPkts.SubscribePacket)
 	assert.Len(mqttSubscribe.Qoss, 1)
 	assert.Equal(snSubscribe.QOS, mqttSubscribe.Qoss[0])
 	assert.Len(mqttSubscribe.Topics, 1)
 	assert.Equal(topic, mqttSubscribe.Topics[0])
 
 	// GW <--SUBACK-- MQTT broker
-	mqttSuback := mqttPackets.NewControlPacket(mqttPackets.Suback).(*mqttPackets.SubackPacket)
+	mqttSuback := mqPkts.NewControlPacket(mqPkts.Suback).(*mqPkts.SubackPacket)
 	mqttSuback.MessageID = mqttSubscribe.MessageID
 	mqttSuback.ReturnCodes = []byte{snSubscribe.QOS}
 	stp.mqttSend(mqttSuback, false)
@@ -997,12 +997,12 @@ func TestUnsubscribePredefined(t *testing.T) {
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
-	mqttUnsubscribe := stp.mqttRecv().(*mqttPackets.UnsubscribePacket)
+	mqttUnsubscribe := stp.mqttRecv().(*mqPkts.UnsubscribePacket)
 	assert.Len(mqttUnsubscribe.Topics, 1)
 	assert.Equal(topic, mqttUnsubscribe.Topics[0])
 
 	// GW <--UNSUBACK-- MQTT broker
-	mqttUnsuback := mqttPackets.NewControlPacket(mqttPackets.Unsuback).(*mqttPackets.UnsubackPacket)
+	mqttUnsuback := mqPkts.NewControlPacket(mqPkts.Unsuback).(*mqPkts.UnsubackPacket)
 	mqttUnsuback.MessageID = mqttUnsubscribe.MessageID
 	stp.mqttSend(mqttUnsuback, false)
 
@@ -1050,7 +1050,7 @@ func TestLastWill(t *testing.T) {
 	stp.snSend(snWillMsg, false)
 
 	// GW --CONNECT--> MQTT broker
-	mqttConnect := stp.mqttRecv().(*mqttPackets.ConnectPacket)
+	mqttConnect := stp.mqttRecv().(*mqPkts.ConnectPacket)
 	assert.True(mqttConnect.WillFlag)
 	assert.Equal(willTopic, mqttConnect.WillTopic)
 	assert.Equal(willPayload, mqttConnect.WillMessage)
@@ -1058,8 +1058,8 @@ func TestLastWill(t *testing.T) {
 	assert.Equal(willQos, mqttConnect.WillQos)
 
 	// GW <--CONNACK-- MQTT broker
-	mqttConnack := mqttPackets.NewControlPacket(mqttPackets.Connack).(*mqttPackets.ConnackPacket)
-	mqttConnack.ReturnCode = mqttPackets.Accepted
+	mqttConnack := mqPkts.NewControlPacket(mqPkts.Connack).(*mqPkts.ConnackPacket)
+	mqttConnack.ReturnCode = mqPkts.Accepted
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
@@ -1145,7 +1145,7 @@ func TestAuthSuccess(t *testing.T) {
 	stp.snSend(snAuth, false)
 
 	// GW --CONNECT--> MQTT broker
-	mqttConnect := stp.mqttRecv().(*mqttPackets.ConnectPacket)
+	mqttConnect := stp.mqttRecv().(*mqPkts.ConnectPacket)
 	assert.Equal(string(snConnect.ClientID), mqttConnect.ClientIdentifier)
 	assert.Equal(snConnect.CleanSession, mqttConnect.CleanSession)
 	assert.Equal(snConnect.Duration, mqttConnect.Keepalive)
@@ -1157,8 +1157,8 @@ func TestAuthSuccess(t *testing.T) {
 	assert.Equal(password, mqttConnect.Password)
 
 	// GW <--CONNACK-- MQTT broker
-	mqttConnack := mqttPackets.NewControlPacket(mqttPackets.Connack).(*mqttPackets.ConnackPacket)
-	mqttConnack.ReturnCode = mqttPackets.Accepted
+	mqttConnack := mqPkts.NewControlPacket(mqPkts.Connack).(*mqPkts.ConnackPacket)
+	mqttConnack.ReturnCode = mqPkts.Accepted
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
@@ -1189,7 +1189,7 @@ func TestAuthFail(t *testing.T) {
 	stp.snSend(snAuth, false)
 
 	// GW --CONNECT--> MQTT broker
-	mqttConnect := stp.mqttRecv().(*mqttPackets.ConnectPacket)
+	mqttConnect := stp.mqttRecv().(*mqPkts.ConnectPacket)
 	assert.Equal(string(snConnect.ClientID), mqttConnect.ClientIdentifier)
 	assert.Equal(snConnect.CleanSession, mqttConnect.CleanSession)
 	assert.Equal(snConnect.Duration, mqttConnect.Keepalive)
@@ -1201,8 +1201,8 @@ func TestAuthFail(t *testing.T) {
 	assert.Equal(password, mqttConnect.Password)
 
 	// GW <--CONNACK-- MQTT broker
-	mqttConnack := mqttPackets.NewControlPacket(mqttPackets.Connack).(*mqttPackets.ConnackPacket)
-	mqttConnack.ReturnCode = mqttPackets.ErrRefusedNotAuthorised
+	mqttConnack := mqPkts.NewControlPacket(mqPkts.Connack).(*mqPkts.ConnackPacket)
+	mqttConnack.ReturnCode = mqPkts.ErrRefusedNotAuthorised
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
@@ -1344,10 +1344,10 @@ func (stp *testSetup) snRecv() snPkts1.Packet {
 	return pkt
 }
 
-func (stp *testSetup) mqttSend(pkt mqttPackets.ControlPacket, setMsgID bool) {
+func (stp *testSetup) mqttSend(pkt mqPkts.ControlPacket, setMsgID bool) {
 	if setMsgID {
 		switch pkt2 := pkt.(type) {
-		case *mqttPackets.PublishPacket:
+		case *mqPkts.PublishPacket:
 			pkt2.MessageID = stp.mqttNextMsgID
 		default:
 			stp.t.Fatalf("Cannot set MsgID for %v", pkt)
@@ -1361,8 +1361,8 @@ func (stp *testSetup) mqttSend(pkt mqttPackets.ControlPacket, setMsgID bool) {
 	}
 }
 
-func (stp *testSetup) mqttRecv() mqttPackets.ControlPacket {
-	pkt, err := mqttPackets.ReadPacket(stp.mqttConn)
+func (stp *testSetup) mqttRecv() mqPkts.ControlPacket {
+	pkt, err := mqPkts.ReadPacket(stp.mqttConn)
 	if err != nil {
 		stp.t.Fatal(err)
 	}
@@ -1458,7 +1458,7 @@ func (stp *testSetup) connect() {
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker
-	mqttConnect := stp.mqttRecv().(*mqttPackets.ConnectPacket)
+	mqttConnect := stp.mqttRecv().(*mqPkts.ConnectPacket)
 	assert.Equal(string(snConnect.ClientID), mqttConnect.ClientIdentifier)
 	assert.Equal(snConnect.CleanSession, mqttConnect.CleanSession)
 	assert.Equal(snConnect.Duration, mqttConnect.Keepalive)
@@ -1466,8 +1466,8 @@ func (stp *testSetup) connect() {
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
 	// GW <--CONNACK-- MQTT broker
-	mqttConnack := mqttPackets.NewControlPacket(mqttPackets.Connack).(*mqttPackets.ConnackPacket)
-	mqttConnack.ReturnCode = mqttPackets.Accepted
+	mqttConnack := mqPkts.NewControlPacket(mqPkts.Connack).(*mqPkts.ConnackPacket)
+	mqttConnack.ReturnCode = mqPkts.Accepted
 	stp.mqttSend(mqttConnack, false)
 
 	// client <--CONNACK-- GW
@@ -1504,14 +1504,14 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
-	mqttSubscribe := stp.mqttRecv().(*mqttPackets.SubscribePacket)
+	mqttSubscribe := stp.mqttRecv().(*mqPkts.SubscribePacket)
 	assert.Len(mqttSubscribe.Qoss, 1)
 	assert.Equal(snSubscribe.QOS, mqttSubscribe.Qoss[0])
 	assert.Len(mqttSubscribe.Topics, 1)
 	assert.Equal(topic, mqttSubscribe.Topics[0])
 
 	// GW <--SUBACK-- MQTT broker
-	mqttSuback := mqttPackets.NewControlPacket(mqttPackets.Suback).(*mqttPackets.SubackPacket)
+	mqttSuback := mqPkts.NewControlPacket(mqPkts.Suback).(*mqPkts.SubackPacket)
 	mqttSuback.MessageID = mqttSubscribe.MessageID
 	mqttSuback.ReturnCodes = []byte{snSubscribe.QOS}
 	stp.mqttSend(mqttSuback, false)
@@ -1541,14 +1541,14 @@ func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
-	mqttSubscribe := stp.mqttRecv().(*mqttPackets.SubscribePacket)
+	mqttSubscribe := stp.mqttRecv().(*mqPkts.SubscribePacket)
 	assert.Len(mqttSubscribe.Qoss, 1)
 	assert.Equal(snSubscribe.QOS, mqttSubscribe.Qoss[0])
 	assert.Len(mqttSubscribe.Topics, 1)
 	assert.Equal(topic, mqttSubscribe.Topics[0])
 
 	// GW <--SUBACK-- MQTT broker
-	mqttSuback := mqttPackets.NewControlPacket(mqttPackets.Suback).(*mqttPackets.SubackPacket)
+	mqttSuback := mqPkts.NewControlPacket(mqPkts.Suback).(*mqPkts.SubackPacket)
 	mqttSuback.MessageID = mqttSubscribe.MessageID
 	mqttSuback.ReturnCodes = []byte{snSubscribe.QOS}
 	stp.mqttSend(mqttSuback, false)
@@ -1569,8 +1569,8 @@ func (stp *testSetup) disconnect() {
 	stp.snSend(snDisconnect, true)
 
 	// GW --DISCONNECT--> MQTT broker
-	mqttDisconnect := stp.mqttRecv().(*mqttPackets.DisconnectPacket)
-	assert.Equal(uint8(mqttPackets.Disconnect), mqttDisconnect.MessageType)
+	mqttDisconnect := stp.mqttRecv().(*mqPkts.DisconnectPacket)
+	assert.Equal(uint8(mqPkts.Disconnect), mqttDisconnect.MessageType)
 
 	// client <--DISCONNECT-- GW
 	snDisconnectReply := stp.snRecv().(*snPkts1.Disconnect)

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -28,11 +28,12 @@ import (
 	"time"
 
 	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+	"golang.org/x/sync/errgroup"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
-	"golang.org/x/sync/errgroup"
 )
 
 type handler struct {

--- a/gateway/subscribe_transaction.go
+++ b/gateway/subscribe_transaction.go
@@ -7,7 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
+	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
+
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -37,7 +38,7 @@ func newSubscribeTransaction(ctx context.Context, h *handler, msgID uint16, topi
 	}
 }
 
-func (t *subscribeTransaction) Suback(mqSuback *mqttPackets.SubackPacket) error {
+func (t *subscribeTransaction) Suback(mqSuback *mqPkts.SubackPacket) error {
 	if len(mqSuback.ReturnCodes) != 1 {
 		err := fmt.Errorf("unexpected ReturnCodes length in MQTT/SUBACK: %d", len(mqSuback.ReturnCodes))
 		t.Fail(err)

--- a/gateway/subscribe_transaction.go
+++ b/gateway/subscribe_transaction.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	mqttPackets "github.com/eclipse/paho.mqtt.golang/packets"
-	snPkts "github.com/energomonitor/bisquitt/packets1"
+	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
 )
@@ -45,15 +45,15 @@ func (t *subscribeTransaction) Suback(mqSuback *mqttPackets.SubackPacket) error 
 	}
 	// MQTT Return codes 0-2 means "Success, QoS 0-2" but in MQTT-SN only 0
 	// means success!
-	var returnCode snPkts.ReturnCode
+	var returnCode snPkts1.ReturnCode
 	if mqSuback.ReturnCodes[0] <= 2 {
-		returnCode = snPkts.RC_ACCEPTED
+		returnCode = snPkts1.RC_ACCEPTED
 		t.Success()
 	} else {
-		returnCode = snPkts.RC_NOT_SUPPORTED
+		returnCode = snPkts1.RC_NOT_SUPPORTED
 		t.Fail(fmt.Errorf("MQTT SUBACK return code: %d", mqSuback.ReturnCodes[0]))
 	}
-	snMsg := snPkts.NewSuback(t.topicID, mqSuback.Qos, returnCode)
+	snMsg := snPkts1.NewSuback(t.topicID, mqSuback.Qos, returnCode)
 	snMsg.SetMessageID(mqSuback.MessageID)
 	return t.handler.snSend(snMsg)
 }

--- a/transactions/transaction_store.go
+++ b/transactions/transaction_store.go
@@ -3,7 +3,7 @@ package transactions
 import (
 	"sync"
 
-	pkts "github.com/energomonitor/bisquitt/packets1"
+	pkts1 "github.com/energomonitor/bisquitt/packets1"
 )
 
 // TransactionStore stores transactions by MessageID or MessageType
@@ -14,14 +14,14 @@ import (
 type TransactionStore struct {
 	sync.RWMutex
 	byMsgID   map[uint16]Transaction
-	byMsgType map[pkts.MessageType]Transaction
+	byMsgType map[pkts1.MessageType]Transaction
 }
 
 // NewTransactionStore creates a new transaction store.
 func NewTransactionStore() *TransactionStore {
 	return &TransactionStore{
 		byMsgID:   make(map[uint16]Transaction),
-		byMsgType: make(map[pkts.MessageType]Transaction),
+		byMsgType: make(map[pkts1.MessageType]Transaction),
 	}
 }
 
@@ -33,7 +33,7 @@ func (ts *TransactionStore) Store(msgID uint16, transaction Transaction) {
 }
 
 // StoreByType inserts a new transaction to the store by the MessageType.
-func (ts *TransactionStore) StoreByType(msgType pkts.MessageType, transaction Transaction) {
+func (ts *TransactionStore) StoreByType(msgType pkts1.MessageType, transaction Transaction) {
 	ts.Lock()
 	defer ts.Unlock()
 	ts.byMsgType[msgType] = transaction
@@ -48,7 +48,7 @@ func (ts *TransactionStore) Get(msgID uint16) (Transaction, bool) {
 }
 
 // GetByType retrieves a transaction from the store by the MessageType.
-func (ts *TransactionStore) GetByType(msgType pkts.MessageType) (Transaction, bool) {
+func (ts *TransactionStore) GetByType(msgType pkts1.MessageType) (Transaction, bool) {
 	ts.Lock()
 	defer ts.Unlock()
 	transaction, ok := ts.byMsgType[msgType]
@@ -63,7 +63,7 @@ func (ts *TransactionStore) Delete(msgID uint16) {
 }
 
 // DeleteByType removes a transaction from the store by the MessageType.
-func (ts *TransactionStore) DeleteByType(msgType pkts.MessageType) {
+func (ts *TransactionStore) DeleteByType(msgType pkts1.MessageType) {
 	ts.Lock()
 	defer ts.Unlock()
 	delete(ts.byMsgType, msgType)


### PR DESCRIPTION
This PR unifies `import`s format throughout the code:
- `packets1` package is always imported as `[sn]Pkts1`
- `paho.mqtt.golang` package is likewise imported as `mqPkts`
- `import` statement structure is unified

All changes are aesthetic only, no functional change.