### PR TITLE
Return specific context error from `ConnWithContext.{Read,Write}()`

### DIFF
--- a/util/conn_with_context.go
+++ b/util/conn_with_context.go
@@ -35,7 +35,7 @@ func (c *ConnWithContext) Read(p []byte) (int, error) {
 AGAIN:
 	select {
 	case <-c.ctx.Done():
-		return 0, context.Canceled
+		return 0, c.ctx.Err()
 	default:
 		// continue
 	}
@@ -63,7 +63,7 @@ func (c *ConnWithContext) Write(b []byte) (int, error) {
 AGAIN:
 	select {
 	case <-c.ctx.Done():
-		return 0, context.Canceled
+		return 0, c.ctx.Err()
 	default:
 		// continue
 	}


### PR DESCRIPTION
When context is closed because of an error, this error should also be returned from `ConnWithContext.{Read,Write}()` because it could be used by the caller.

This commit fixes e.g. a bug in `bisquitt-sub` where on some internal errors, only "context canceled" error is printed on the console, instead of the real error which caused the cancellation.