### PR TITLE
Replace "message" with "packet"

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -172,10 +172,10 @@ func TestConnectAuthWill(t *testing.T) {
 		stp.send(pkts1.NewWillTopicReq())
 
 		// client --WILLTOPIC--> GW
-		willTopicMsg := stp.recv().(*pkts1.WillTopic)
-		assert.Equal(willTopic, willTopicMsg.WillTopic)
-		assert.Equal(willQOS, willTopicMsg.QOS)
-		assert.Equal(willRetained, willTopicMsg.Retain)
+		willTopicPkt := stp.recv().(*pkts1.WillTopic)
+		assert.Equal(willTopic, willTopicPkt.WillTopic)
+		assert.Equal(willQOS, willTopicPkt.QOS)
+		assert.Equal(willRetained, willTopicPkt.Retain)
 
 		// client <--WILLMSGREQ-- GW
 		willMsgReq := pkts1.NewWillMsgReq()

--- a/client/disconnect_transaction.go
+++ b/client/disconnect_transaction.go
@@ -16,9 +16,9 @@ func newDisconnectTransaction(client *Client) *disconnectTransaction {
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts1.Packet))
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.DeleteByType(pkts1.DISCONNECT)

--- a/client/ping_transaction.go
+++ b/client/ping_transaction.go
@@ -16,9 +16,9 @@ func newPingTransaction(client *Client) *pingTransaction {
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts1.Packet))
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.DeleteByType(pkts1.PINGREQ)

--- a/client/publish_qos1_transaction.go
+++ b/client/publish_qos1_transaction.go
@@ -18,9 +18,9 @@ func newPublishQOS1Transaction(client *Client, msgID uint16) *publishQOS1Transac
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts1.Packet))
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)

--- a/client/publish_qos2_transaction.go
+++ b/client/publish_qos2_transaction.go
@@ -18,9 +18,9 @@ func newPublishQOS2Transaction(client *Client, msgID uint16) *publishQOS2Transac
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts1.Packet))
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)

--- a/client/register_transaction.go
+++ b/client/register_transaction.go
@@ -18,9 +18,9 @@ func newRegisterTransaction(client *Client, msgID uint16, topic string) *registe
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts1.Packet))
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)

--- a/client/subscribe_transaction.go
+++ b/client/subscribe_transaction.go
@@ -20,11 +20,11 @@ func newSubscribeTransaction(client *Client, msgID uint16, callback MessageHandl
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					dupMsg := lastMsg.(pkts1.PacketWithDUP)
-					dupMsg.SetDUP(true)
-					return client.send(lastMsg.(pkts1.Packet))
+					dupPkt := lastPkt.(pkts1.PacketWithDUP)
+					dupPkt.SetDUP(true)
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					tLog.Debug("Deleted.")

--- a/client/unsubscribe_transaction.go
+++ b/client/unsubscribe_transaction.go
@@ -19,9 +19,9 @@ func newUnsubscribeTransaction(client *Client, msgID uint16) *unsubscribeTransac
 		transaction: &transaction{
 			RetryTransaction: transactions.NewRetryTransaction(
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
-				func(lastMsg interface{}) error {
+				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastMsg.(pkts1.Packet))
+					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
 					tLog.Debug("Deleted.")

--- a/gateway/broker_publish_transaction.go
+++ b/gateway/broker_publish_transaction.go
@@ -29,8 +29,8 @@ type transactionWithRegack interface {
 type brokerPublishTransaction interface {
 	transactions.StatefulTransaction
 	SetSNPublish(*snPkts1.Publish)
-	ProceedSN(newState transactionState, snMsg snPkts1.Packet) error
-	ProceedMQTT(newState transactionState, mqMsg mqPkts.ControlPacket) error
+	ProceedSN(newState transactionState, snPkt snPkts1.Packet) error
+	ProceedMQTT(newState transactionState, mqPkt mqPkts.ControlPacket) error
 }
 
 type brokerPublishTransactionBase struct {
@@ -58,9 +58,9 @@ func (t *brokerPublishTransactionBase) regack(snRegack *snPkts1.Regack, newState
 	return t.ProceedSN(newState, t.snPublish)
 }
 
-func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snMsg snPkts1.Packet) error {
-	t.Proceed(newState, snMsg)
-	if err := t.handler.snSend(snMsg); err != nil {
+func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snPkt snPkts1.Packet) error {
+	t.Proceed(newState, snPkt)
+	if err := t.handler.snSend(snPkt); err != nil {
 		t.Fail(err)
 		return err
 	}
@@ -70,9 +70,9 @@ func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snMs
 	return nil
 }
 
-func (t *brokerPublishTransactionBase) ProceedMQTT(newState transactionState, mqMsg mqPkts.ControlPacket) error {
-	t.Proceed(newState, mqMsg)
-	if err := t.handler.mqttSend(mqMsg); err != nil {
+func (t *brokerPublishTransactionBase) ProceedMQTT(newState transactionState, mqPkt mqPkts.ControlPacket) error {
+	t.Proceed(newState, mqPkt)
+	if err := t.handler.mqttSend(mqPkt); err != nil {
 		t.Fail(err)
 		return err
 	}
@@ -88,8 +88,8 @@ func (t *brokerPublishTransactionBase) resend(pktx interface{}) error {
 	switch pkt := pktx.(type) {
 	case snPkts1.Packet:
 		// Set DUP if applicable.
-		if dupMsg, ok := pkt.(snPkts1.PacketWithDUP); ok {
-			dupMsg.SetDUP(true)
+		if dupPkt, ok := pkt.(snPkts1.PacketWithDUP); ok {
+			dupPkt.SetDUP(true)
 		}
 		return t.handler.snSend(pkt)
 	case mqPkts.ControlPacket:

--- a/gateway/connect_transaction.go
+++ b/gateway/connect_transaction.go
@@ -79,10 +79,10 @@ func (t *connectTransaction) Start(ctx context.Context) error {
 	return t.handler.mqttSend(t.mqConnect)
 }
 
-func (t *connectTransaction) Auth(snMsg *snPkts1.Auth) error {
+func (t *connectTransaction) Auth(snPkt *snPkts1.Auth) error {
 	// Extract username and password from PLAIN data.
-	if snMsg.Method == snPkts1.AUTH_PLAIN {
-		user, password, err := snPkts1.DecodePlain(snMsg)
+	if snPkt.Method == snPkts1.AUTH_PLAIN {
+		user, password, err := snPkts1.DecodePlain(snPkt)
 		if err != nil {
 			t.Fail(err)
 			return err
@@ -95,7 +95,7 @@ func (t *connectTransaction) Auth(snMsg *snPkts1.Auth) error {
 		if err := t.SendConnack(snPkts1.RC_NOT_SUPPORTED); err != nil {
 			return err
 		}
-		err := fmt.Errorf("unknown auth method: %#v", snMsg.Method)
+		err := fmt.Errorf("unknown auth method: %#v", snPkt.Method)
 		t.Fail(err)
 		return err
 	}

--- a/gateway/subscribe_transaction.go
+++ b/gateway/subscribe_transaction.go
@@ -54,7 +54,7 @@ func (t *subscribeTransaction) Suback(mqSuback *mqPkts.SubackPacket) error {
 		returnCode = snPkts1.RC_NOT_SUPPORTED
 		t.Fail(fmt.Errorf("MQTT SUBACK return code: %d", mqSuback.ReturnCodes[0]))
 	}
-	snMsg := snPkts1.NewSuback(t.topicID, mqSuback.Qos, returnCode)
-	snMsg.SetMessageID(mqSuback.MessageID)
-	return t.handler.snSend(snMsg)
+	snPkt := snPkts1.NewSuback(t.topicID, mqSuback.Qos, returnCode)
+	snPkt.SetMessageID(mqSuback.MessageID)
+	return t.handler.snSend(snPkt)
 }

--- a/transactions/transaction_store.go
+++ b/transactions/transaction_store.go
@@ -13,58 +13,58 @@ import (
 // It's safe for concurrent use.
 type TransactionStore struct {
 	sync.RWMutex
-	byMsgID   map[uint16]Transaction
-	byMsgType map[pkts1.MessageType]Transaction
+	byPktID   map[uint16]Transaction
+	byPktType map[pkts1.MessageType]Transaction
 }
 
 // NewTransactionStore creates a new transaction store.
 func NewTransactionStore() *TransactionStore {
 	return &TransactionStore{
-		byMsgID:   make(map[uint16]Transaction),
-		byMsgType: make(map[pkts1.MessageType]Transaction),
+		byPktID:   make(map[uint16]Transaction),
+		byPktType: make(map[pkts1.MessageType]Transaction),
 	}
 }
 
 // Store inserts a new transaction to the store by the MessageID.
-func (ts *TransactionStore) Store(msgID uint16, transaction Transaction) {
+func (ts *TransactionStore) Store(pktID uint16, transaction Transaction) {
 	ts.Lock()
 	defer ts.Unlock()
-	ts.byMsgID[msgID] = transaction
+	ts.byPktID[pktID] = transaction
 }
 
 // StoreByType inserts a new transaction to the store by the MessageType.
-func (ts *TransactionStore) StoreByType(msgType pkts1.MessageType, transaction Transaction) {
+func (ts *TransactionStore) StoreByType(pktType pkts1.MessageType, transaction Transaction) {
 	ts.Lock()
 	defer ts.Unlock()
-	ts.byMsgType[msgType] = transaction
+	ts.byPktType[pktType] = transaction
 }
 
 // Get retrieves a transaction from the store by the MessageID.
-func (ts *TransactionStore) Get(msgID uint16) (Transaction, bool) {
+func (ts *TransactionStore) Get(pktID uint16) (Transaction, bool) {
 	ts.RLock()
 	defer ts.RUnlock()
-	transaction, ok := ts.byMsgID[msgID]
+	transaction, ok := ts.byPktID[pktID]
 	return transaction, ok
 }
 
 // GetByType retrieves a transaction from the store by the MessageType.
-func (ts *TransactionStore) GetByType(msgType pkts1.MessageType) (Transaction, bool) {
+func (ts *TransactionStore) GetByType(pktType pkts1.MessageType) (Transaction, bool) {
 	ts.Lock()
 	defer ts.Unlock()
-	transaction, ok := ts.byMsgType[msgType]
+	transaction, ok := ts.byPktType[pktType]
 	return transaction, ok
 }
 
 // Delete removes a transaction from the store by the MessageID.
-func (ts *TransactionStore) Delete(msgID uint16) {
+func (ts *TransactionStore) Delete(pktID uint16) {
 	ts.Lock()
 	defer ts.Unlock()
-	delete(ts.byMsgID, msgID)
+	delete(ts.byPktID, pktID)
 }
 
 // DeleteByType removes a transaction from the store by the MessageType.
-func (ts *TransactionStore) DeleteByType(msgType pkts1.MessageType) {
+func (ts *TransactionStore) DeleteByType(pktType pkts1.MessageType) {
 	ts.Lock()
 	defer ts.Unlock()
-	delete(ts.byMsgType, msgType)
+	delete(ts.byPktType, pktType)
 }


### PR DESCRIPTION
The MQTT-SN v.2.0 specification uses the term "packet" instead of "message". This commit replaces "message", "msg" with "packet", "pkt" wherever it's not a terminus technicus from MQTT-SN v.1.2.