### PR TITLE
Move common v.1 and v.2 packets code into `packets` package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -139,7 +139,7 @@ func NewClient(log util.Logger, cfg *ClientConfig) *Client {
 		state:            &state,
 		stateChangeCh:    make(chan util.ClientState, 1),
 		log:              log,
-		msgID:            util.NewIDSequence(pkts1.MinMessageID, pkts1.MaxMessageID),
+		msgID:            util.NewIDSequence(pkts.MinPacketID, pkts.MaxPacketID),
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -381,8 +381,8 @@ func (c *Client) subscribe(topicName string, topicIDType uint8, topicID uint16, 
 // long, it's treated as a short topic. The received packets are passed to the
 // provided callback.
 func (c *Client) Subscribe(topic string, qos uint8, callback MessageHandlerFunc) error {
-	if pkts1.IsShortTopic(topic) {
-		return c.subscribe("", pkts1.TIT_SHORT, pkts1.EncodeShortTopic(topic), qos, callback)
+	if pkts.IsShortTopic(topic) {
+		return c.subscribe("", pkts1.TIT_SHORT, pkts.EncodeShortTopic(topic), qos, callback)
 	} else {
 		return c.subscribe(topic, pkts1.TIT_STRING, 0, qos, callback)
 	}
@@ -415,8 +415,8 @@ func (c *Client) unsubscribe(topicName string, topicIDType uint8, topicID uint16
 // Unsubscribe unsubscribes from a topic. If the topic is 2 characters long,
 // it's treated as a short topic.
 func (c *Client) Unsubscribe(topic string) error {
-	if pkts1.IsShortTopic(topic) {
-		return c.unsubscribe("", pkts1.TIT_SHORT, pkts1.EncodeShortTopic(topic))
+	if pkts.IsShortTopic(topic) {
+		return c.unsubscribe("", pkts1.TIT_SHORT, pkts.EncodeShortTopic(topic))
 	} else {
 		return c.unsubscribe(topic, pkts1.TIT_STRING, 0)
 	}
@@ -465,9 +465,9 @@ func (c *Client) publish(topicIDType uint8, topicID uint16, qos uint8, retain bo
 func (c *Client) Publish(topic string, qos uint8, retain bool, payload []byte) error {
 	var topicIDType uint8
 	var topicID uint16
-	if pkts1.IsShortTopic(topic) {
+	if pkts.IsShortTopic(topic) {
 		topicIDType = pkts1.TIT_SHORT
-		topicID = pkts1.EncodeShortTopic(topic)
+		topicID = pkts.EncodeShortTopic(topic)
 	} else {
 		topicIDType = pkts1.TIT_REGISTERED
 		var ok bool

--- a/client/client.go
+++ b/client/client.go
@@ -68,6 +68,7 @@ import (
 	"github.com/pion/dtls/v2/pkg/crypto/selfsign"
 	"golang.org/x/sync/errgroup"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
@@ -309,7 +310,7 @@ func (c *Client) Connect() error {
 
 	for i := uint(0); i < c.cfg.RetryCount+1; i++ {
 		transaction := newConnectTransaction(c.groupCtx, c)
-		c.transactions.StoreByType(pkts1.CONNECT, transaction)
+		c.transactions.StoreByType(pkts.CONNECT, transaction)
 
 		if err := c.send(connect); err != nil {
 			return err
@@ -489,7 +490,7 @@ func (c *Client) PublishPredefined(topicID uint16, qos uint8, retain bool, paylo
 func (c *Client) Ping() error {
 	transaction := newPingTransaction(c)
 	ping := pkts1.NewPingreq(nil)
-	c.transactions.StoreByType(pkts1.PINGREQ, transaction)
+	c.transactions.StoreByType(pkts.PINGREQ, transaction)
 	transaction.Proceed(nil, ping)
 	if err := c.send(ping); err != nil {
 		transaction.Fail(err)
@@ -505,7 +506,7 @@ func (c *Client) Ping() error {
 // Sleep informs the MQTT-SN gateway that the client is going to sleep.
 func (c *Client) Sleep(duration time.Duration) error {
 	transaction := newSleepTransaction(c, duration)
-	c.transactions.StoreByType(pkts1.DISCONNECT, transaction)
+	c.transactions.StoreByType(pkts.DISCONNECT, transaction)
 	if err := transaction.Sleep(); err != nil {
 		return err
 	}
@@ -530,7 +531,7 @@ func (c *Client) Disconnect() error {
 	}
 	transaction := newDisconnectTransaction(c)
 	disconnect := pkts1.NewDisconnect(0)
-	c.transactions.StoreByType(pkts1.DISCONNECT, transaction)
+	c.transactions.StoreByType(pkts.DISCONNECT, transaction)
 	transaction.Proceed(awaitingDisconnect, disconnect)
 	if err := c.send(disconnect); err != nil {
 		transaction.Fail(err)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
@@ -1884,7 +1885,7 @@ func (stp *testSetup) recv() pkts1.Packet {
 	}
 
 	pktReader := bytes.NewReader(buff[:n])
-	header := &pkts1.Header{}
+	header := &pkts.Header{}
 	header.Unpack(pktReader)
 	pkt := pkts1.NewPacketWithHeader(*header)
 	pkt.Unpack(pktReader)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -381,7 +381,7 @@ func TestPublishQOS0Short(t *testing.T) {
 	topic := "ab"
 	qos := uint8(0)
 	retain := true
-	topicID := pkts1.EncodeShortTopic(topic)
+	topicID := pkts.EncodeShortTopic(topic)
 
 	stp := newTestSetup(t, clientID)
 	defer stp.cancel()
@@ -577,7 +577,7 @@ func TestPublishQOS1Short(t *testing.T) {
 	topic := "ab"
 	qos := uint8(1)
 	retain := true
-	topicID := pkts1.EncodeShortTopic(topic)
+	topicID := pkts.EncodeShortTopic(topic)
 
 	stp := newTestSetup(t, clientID)
 	defer stp.cancel()
@@ -809,7 +809,7 @@ func TestPublishQOS2Short(t *testing.T) {
 	topic := "ab"
 	qos := uint8(2)
 	retain := true
-	topicID := pkts1.EncodeShortTopic(topic)
+	topicID := pkts.EncodeShortTopic(topic)
 
 	stp := newTestSetup(t, clientID)
 	defer stp.cancel()
@@ -1238,7 +1238,7 @@ func TestSubscribeShort(t *testing.T) {
 
 		stp.connect(clientID)
 
-		encodedTopic := pkts1.EncodeShortTopic(topic)
+		encodedTopic := pkts.EncodeShortTopic(topic)
 
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
@@ -1435,7 +1435,7 @@ func TestUnsubscribeShort(t *testing.T) {
 
 		stp.connect(clientID)
 
-		encodedTopic := pkts1.EncodeShortTopic(topic)
+		encodedTopic := pkts.EncodeShortTopic(topic)
 
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
@@ -1634,7 +1634,7 @@ func TestSleep(t *testing.T) {
 			assert.Equal(util.StateAwake, stp.client.state.Get())
 
 			// client <--PUBLISH-- GW
-			encodedTopic := pkts1.EncodeShortTopic(topic)
+			encodedTopic := pkts.EncodeShortTopic(topic)
 			publish := pkts1.NewPublish(encodedTopic,
 				pkts1.TIT_SHORT, []byte(""), 0, false, false)
 			stp.send(publish)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1869,13 +1869,13 @@ func (stp *testSetup) createSocketPair(sockType string, rand *rand.Rand) (*net.U
 	return listener, conn
 }
 
-func (stp *testSetup) send(pkt pkts1.Packet) {
+func (stp *testSetup) send(pkt pkts.Packet) {
 	if err := pkt.Write(stp.conn); err != nil {
 		stp.t.Fatal(err)
 	}
 }
 
-func (stp *testSetup) recv() pkts1.Packet {
+func (stp *testSetup) recv() pkts.Packet {
 	buff := make([]byte, maxTestPktLength)
 	n, err := stp.conn.Read(buff)
 	if err != nil {

--- a/client/connect_transaction.go
+++ b/client/connect_transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -21,7 +22,7 @@ func newConnectTransaction(ctx context.Context, client *Client) *connectTransact
 		TimedTransaction: transactions.NewTimedTransaction(
 			ctx, client.cfg.ConnectTimeout,
 			func() {
-				client.transactions.DeleteByType(pkts1.CONNECT)
+				client.transactions.DeleteByType(pkts.CONNECT)
 				tLog.Debug("Deleted.")
 			},
 		),

--- a/client/disconnect_transaction.go
+++ b/client/disconnect_transaction.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -21,7 +22,7 @@ func newDisconnectTransaction(client *Client) *disconnectTransaction {
 					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
-					client.transactions.DeleteByType(pkts1.DISCONNECT)
+					client.transactions.DeleteByType(pkts.DISCONNECT)
 					tLog.Debug("Deleted.")
 				},
 			),

--- a/client/disconnect_transaction.go
+++ b/client/disconnect_transaction.go
@@ -19,7 +19,7 @@ func newDisconnectTransaction(client *Client) *disconnectTransaction {
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					client.transactions.DeleteByType(pkts.DISCONNECT)

--- a/client/net.go
+++ b/client/net.go
@@ -8,6 +8,7 @@ import (
 
 	dtlsProtocol "github.com/pion/dtls/v2/pkg/protocol"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/util"
 )
@@ -121,7 +122,7 @@ func (c *Client) topicForPublish(pkt *pkts1.Publish) (string, error) {
 func (c *Client) handlePacket(pktx pkts1.Packet) error {
 	switch pkt := pktx.(type) {
 	case *pkts1.Connack:
-		transactionx, _ := c.transactions.GetByType(pkts1.CONNECT)
+		transactionx, _ := c.transactions.GetByType(pkts.CONNECT)
 		transaction, ok := transactionx.(*connectTransaction)
 		if !ok {
 			c.log.Error("Unexpected transaction type %T for packet: %v", transactionx, pkt)
@@ -260,7 +261,7 @@ func (c *Client) handlePacket(pktx pkts1.Packet) error {
 		return nil
 
 	case *pkts1.Disconnect:
-		transactionx, ok := c.transactions.GetByType(pkts1.DISCONNECT)
+		transactionx, ok := c.transactions.GetByType(pkts.DISCONNECT)
 		if !ok {
 			// Unsolicited DISCONNECT from broker.
 			c.setState(util.StateDisconnected)
@@ -287,10 +288,10 @@ func (c *Client) handlePacket(pktx pkts1.Packet) error {
 		return c.send(willMsg)
 
 	case *pkts1.Pingresp:
-		transactionx, ok := c.transactions.GetByType(pkts1.PINGREQ)
+		transactionx, ok := c.transactions.GetByType(pkts.PINGREQ)
 		if !ok {
 			// Sleep transaction.
-			transactionx, _ = c.transactions.GetByType(pkts1.DISCONNECT)
+			transactionx, _ = c.transactions.GetByType(pkts.DISCONNECT)
 		}
 		transaction, ok := transactionx.(transactionWithPingresp)
 		if !ok {

--- a/client/net.go
+++ b/client/net.go
@@ -13,7 +13,7 @@ import (
 	"github.com/energomonitor/bisquitt/util"
 )
 
-func (c *Client) send(pkt pkts1.Packet) error {
+func (c *Client) send(pkt pkts.Packet) error {
 	c.log.Debug("<- %v", pkt)
 	return pkt.Write(c.conn)
 }
@@ -119,7 +119,7 @@ func (c *Client) topicForPublish(pkt *pkts1.Publish) (string, error) {
 	return topic, nil
 }
 
-func (c *Client) handlePacket(pktx pkts1.Packet) error {
+func (c *Client) handlePacket(pktx pkts.Packet) error {
 	switch pkt := pktx.(type) {
 	case *pkts1.Connack:
 		transactionx, _ := c.transactions.GetByType(pkts.CONNECT)

--- a/client/net.go
+++ b/client/net.go
@@ -110,7 +110,7 @@ func (c *Client) topicForPublish(pkt *pkts1.Publish) (string, error) {
 			return "", fmt.Errorf("invalid predefined topic ID: %d", pkt.TopicID)
 		}
 	case pkts1.TIT_SHORT:
-		topic = pkts1.DecodeShortTopic(pkt.TopicID)
+		topic = pkts.DecodeShortTopic(pkt.TopicID)
 
 	default:
 		return "", fmt.Errorf("invalid Topic ID Type: %d", pkt.TopicIDType)

--- a/client/ping_transaction.go
+++ b/client/ping_transaction.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -21,7 +22,7 @@ func newPingTransaction(client *Client) *pingTransaction {
 					return client.send(lastPkt.(pkts1.Packet))
 				},
 				func() {
-					client.transactions.DeleteByType(pkts1.PINGREQ)
+					client.transactions.DeleteByType(pkts.PINGREQ)
 					tLog.Debug("Deleted.")
 				},
 			),

--- a/client/ping_transaction.go
+++ b/client/ping_transaction.go
@@ -19,7 +19,7 @@ func newPingTransaction(client *Client) *pingTransaction {
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					client.transactions.DeleteByType(pkts.PINGREQ)

--- a/client/publish_qos1_transaction.go
+++ b/client/publish_qos1_transaction.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -20,7 +21,7 @@ func newPublishQOS1Transaction(client *Client, msgID uint16) *publishQOS1Transac
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)

--- a/client/publish_qos2_transaction.go
+++ b/client/publish_qos2_transaction.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -20,7 +21,7 @@ func newPublishQOS2Transaction(client *Client, msgID uint16) *publishQOS2Transac
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)

--- a/client/register_transaction.go
+++ b/client/register_transaction.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -20,7 +21,7 @@ func newRegisterTransaction(client *Client, msgID uint16, topic string) *registe
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					client.transactions.Delete(msgID)

--- a/client/sleep_transaction.go
+++ b/client/sleep_transaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -37,7 +38,7 @@ func newSleepTransaction(client *Client, sleepDuration time.Duration) *sleepTran
 	t.TransactionBase = transactions.NewTransactionBase(
 		func() {
 			t.stopTimer()
-			client.transactions.DeleteByType(pkts1.DISCONNECT)
+			client.transactions.DeleteByType(pkts.DISCONNECT)
 			tLog.Debug("Deleted.")
 		})
 

--- a/client/subscribe_transaction.go
+++ b/client/subscribe_transaction.go
@@ -75,7 +75,7 @@ func (t *subscribeTransaction) Suback(suback *pkts1.Suback) {
 		}
 
 	case pkts1.TIT_SHORT:
-		topicName = pkts1.DecodeShortTopic(subscribe.TopicID)
+		topicName = pkts.DecodeShortTopic(subscribe.TopicID)
 		break
 
 	default:

--- a/client/subscribe_transaction.go
+++ b/client/subscribe_transaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -24,7 +25,7 @@ func newSubscribeTransaction(client *Client, msgID uint16, callback MessageHandl
 					tLog.Debug("Resend.")
 					dupPkt := lastPkt.(pkts1.PacketWithDUP)
 					dupPkt.SetDUP(true)
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					tLog.Debug("Deleted.")

--- a/client/subscribe_transaction.go
+++ b/client/subscribe_transaction.go
@@ -23,7 +23,7 @@ func newSubscribeTransaction(client *Client, msgID uint16, callback MessageHandl
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					dupPkt := lastPkt.(pkts1.PacketWithDUP)
+					dupPkt := lastPkt.(pkts.PacketWithDUP)
 					dupPkt.SetDUP(true)
 					return client.send(lastPkt.(pkts.Packet))
 				},

--- a/client/unsubscribe_transaction.go
+++ b/client/unsubscribe_transaction.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	pkts "github.com/energomonitor/bisquitt/packets"
 	pkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 )
@@ -21,7 +22,7 @@ func newUnsubscribeTransaction(client *Client, msgID uint16) *unsubscribeTransac
 				client.groupCtx, client.cfg.RetryDelay, client.cfg.RetryCount,
 				func(lastPkt interface{}) error {
 					tLog.Debug("Resend.")
-					return client.send(lastPkt.(pkts1.Packet))
+					return client.send(lastPkt.(pkts.Packet))
 				},
 				func() {
 					tLog.Debug("Deleted.")

--- a/client/unsubscribe_transaction.go
+++ b/client/unsubscribe_transaction.go
@@ -52,7 +52,7 @@ func (t *unsubscribeTransaction) Unsuback(_ *pkts1.Unsuback) {
 		}
 
 	case pkts1.TIT_SHORT:
-		topicName = pkts1.DecodeShortTopic(unsubscribe.TopicID)
+		topicName = pkts.DecodeShortTopic(unsubscribe.TopicID)
 
 	default:
 		t.Fail(fmt.Errorf("invalid Topic ID Type: %d", unsubscribe.TopicIDType))

--- a/gateway/broker_publish_transaction.go
+++ b/gateway/broker_publish_transaction.go
@@ -89,7 +89,7 @@ func (t *brokerPublishTransactionBase) resend(pktx interface{}) error {
 	switch pkt := pktx.(type) {
 	case snPkts.Packet:
 		// Set DUP if applicable.
-		if dupPkt, ok := pkt.(snPkts1.PacketWithDUP); ok {
+		if dupPkt, ok := pkt.(snPkts.PacketWithDUP); ok {
 			dupPkt.SetDUP(true)
 		}
 		return t.handler.snSend(pkt)

--- a/gateway/broker_publish_transaction.go
+++ b/gateway/broker_publish_transaction.go
@@ -5,6 +5,7 @@ import (
 
 	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
 
+	snPkts "github.com/energomonitor/bisquitt/packets"
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -29,7 +30,7 @@ type transactionWithRegack interface {
 type brokerPublishTransaction interface {
 	transactions.StatefulTransaction
 	SetSNPublish(*snPkts1.Publish)
-	ProceedSN(newState transactionState, snPkt snPkts1.Packet) error
+	ProceedSN(newState transactionState, snPkt snPkts.Packet) error
 	ProceedMQTT(newState transactionState, mqPkt mqPkts.ControlPacket) error
 }
 
@@ -58,7 +59,7 @@ func (t *brokerPublishTransactionBase) regack(snRegack *snPkts1.Regack, newState
 	return t.ProceedSN(newState, t.snPublish)
 }
 
-func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snPkt snPkts1.Packet) error {
+func (t *brokerPublishTransactionBase) ProceedSN(newState transactionState, snPkt snPkts.Packet) error {
 	t.Proceed(newState, snPkt)
 	if err := t.handler.snSend(snPkt); err != nil {
 		t.Fail(err)
@@ -86,7 +87,7 @@ func (t *brokerPublishTransactionBase) ProceedMQTT(newState transactionState, mq
 func (t *brokerPublishTransactionBase) resend(pktx interface{}) error {
 	t.log.Debug("Resend.")
 	switch pkt := pktx.(type) {
-	case snPkts1.Packet:
+	case snPkts.Packet:
 		// Set DUP if applicable.
 		if dupPkt, ok := pkt.(snPkts1.PacketWithDUP); ok {
 			dupPkt.SetDUP(true)

--- a/gateway/connect_transaction.go
+++ b/gateway/connect_transaction.go
@@ -14,6 +14,7 @@ import (
 
 	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
 
+	snPkts "github.com/energomonitor/bisquitt/packets"
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/transactions"
 	"github.com/energomonitor/bisquitt/util"
@@ -37,7 +38,7 @@ func newConnectTransaction(ctx context.Context, h *handler1, authEnabled bool, m
 		TimedTransaction: transactions.NewTimedTransaction(
 			ctx, connectTransactionTimeout,
 			func() {
-				h.transactions.DeleteByType(snPkts1.CONNECT)
+				h.transactions.DeleteByType(snPkts.CONNECT)
 				tLog.Debug("Deleted.")
 			},
 		),

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -536,8 +536,8 @@ func TestSubscribeQOS0Wildcard(t *testing.T) {
 	// client <--REGISTER-- GW
 	snRegister := stp.snRecv().(*snPkts1.Register)
 	assert.Equal(topic, snRegister.TopicName)
-	assert.GreaterOrEqual(snRegister.MessageID(), snPkts1.MinMessageID)
-	assert.LessOrEqual(snRegister.MessageID(), snPkts1.MaxMessageID)
+	assert.GreaterOrEqual(snRegister.MessageID(), snPkts.MinPacketID)
+	assert.LessOrEqual(snRegister.MessageID(), snPkts.MaxPacketID)
 	topicID := snRegister.TopicID
 
 	// client --REGACK--> GW

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -15,6 +15,7 @@ import (
 	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
 	"github.com/stretchr/testify/assert"
 
+	snPkts "github.com/energomonitor/bisquitt/packets"
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/util"
@@ -59,7 +60,7 @@ func TestRepeatedConnect(t *testing.T) {
 	assert.Equal(byte(4), mqttConnect.ProtocolVersion)
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
-	transaction1, ok := stp.handler.transactions.GetByType(snPkts1.CONNECT)
+	transaction1, ok := stp.handler.transactions.GetByType(snPkts.CONNECT)
 	assert.True(ok)
 
 	// Test transaction1 will be cancelled
@@ -87,7 +88,7 @@ func TestRepeatedConnect(t *testing.T) {
 	assert.Equal(byte(4), mqttConnect.ProtocolVersion)
 	assert.Equal("MQTT", mqttConnect.ProtocolName)
 
-	transaction2, ok := stp.handler.transactions.GetByType(snPkts1.CONNECT)
+	transaction2, ok := stp.handler.transactions.GetByType(snPkts.CONNECT)
 	assert.True(ok)
 	assert.NotEqual(transaction1, transaction2)
 
@@ -1337,7 +1338,7 @@ func (stp *testSetup) snRecv() snPkts1.Packet {
 	}
 
 	pktReader := bytes.NewReader(buff[:n])
-	header := &snPkts1.Header{}
+	header := &snPkts.Header{}
 	header.Unpack(pktReader)
 	pkt := snPkts1.NewPacketWithHeader(*header)
 	pkt.Unpack(pktReader)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1525,8 +1525,8 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	if hasWildcard(topic) {
 		assert.Equal(uint16(0), snSuback.TopicID)
 	} else {
-		assert.GreaterOrEqual(snSuback.TopicID, snPkts1.MinTopicID)
-		assert.LessOrEqual(snSuback.TopicID, snPkts1.MaxTopicID)
+		assert.GreaterOrEqual(snSuback.TopicID, snPkts.MinTopicAlias)
+		assert.LessOrEqual(snSuback.TopicID, snPkts.MaxTopicAlias)
 	}
 
 	return snSuback.TopicID

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1314,7 +1314,7 @@ func (stp *testSetup) createSocketPair(sockType string) (*net.UnixListener, *net
 	return listener, conn
 }
 
-func (stp *testSetup) snSend(pkt snPkts1.Packet, setMsgID bool) {
+func (stp *testSetup) snSend(pkt snPkts.Packet, setMsgID bool) {
 	if setMsgID {
 		if pkt2, ok := pkt.(snPkts1.PacketWithID); ok {
 			pkt2.SetMessageID(stp.snNextMsgID)
@@ -1328,7 +1328,7 @@ func (stp *testSetup) snSend(pkt snPkts1.Packet, setMsgID bool) {
 	}
 }
 
-func (stp *testSetup) snRecv() snPkts1.Packet {
+func (stp *testSetup) snRecv() snPkts.Packet {
 	buff := make([]byte, maxTestPktLength)
 	n, err := stp.snConn.Read(buff)
 	if err != nil {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -294,7 +294,7 @@ func TestDisconnectedPublishQOS0(t *testing.T) {
 	defer stp.cancel()
 
 	snPublish := snPkts1.NewPublish(
-		snPkts1.EncodeShortTopic("ab"),
+		snPkts.EncodeShortTopic("ab"),
 		snPkts1.TIT_SHORT, []byte("test-payload"), 0, false, false,
 	)
 	stp.snSend(snPublish, true)
@@ -322,7 +322,7 @@ func TestDisconnectedAuthPublishQOS3Registered(t *testing.T) {
 	defer stp.cancel()
 
 	topic := "ab"
-	topicID := snPkts1.EncodeShortTopic(topic)
+	topicID := snPkts.EncodeShortTopic(topic)
 	payload := []byte("test-msg-0")
 	qos := uint8(3)
 
@@ -342,7 +342,7 @@ func TestDisconnectedPublishQOS3Short(t *testing.T) {
 	defer stp.cancel()
 
 	topic := "ab"
-	topicID := snPkts1.EncodeShortTopic(topic)
+	topicID := snPkts.EncodeShortTopic(topic)
 	payload := []byte("test-msg-0")
 	qos := uint8(3)
 
@@ -932,7 +932,7 @@ func TestUnsubscribeShort(t *testing.T) {
 	stp.subscribeShort(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(snPkts1.EncodeShortTopic(topic), snPkts1.TIT_SHORT, []byte(""))
+	snUnsubscribe := snPkts1.NewUnsubscribe(snPkts.EncodeShortTopic(topic), snPkts1.TIT_SHORT, []byte(""))
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -1535,10 +1535,10 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 	assert := assert.New(stp.t)
 
-	assert.True(snPkts1.IsShortTopic(topic))
+	assert.True(snPkts.IsShortTopic(topic))
 
 	// client --SUBSCRIBE--> GW
-	topicID := snPkts1.EncodeShortTopic(topic)
+	topicID := snPkts.EncodeShortTopic(topic)
 	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_SHORT, nil, qos, false)
 	stp.snSend(snSubscribe, true)
 

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -30,6 +30,7 @@ import (
 	mqPkts "github.com/eclipse/paho.mqtt.golang/packets"
 	"golang.org/x/sync/errgroup"
 
+	snPkts "github.com/energomonitor/bisquitt/packets"
 	snPkts1 "github.com/energomonitor/bisquitt/packets1"
 	"github.com/energomonitor/bisquitt/topics"
 	"github.com/energomonitor/bisquitt/transactions"
@@ -362,7 +363,7 @@ func (h *handler1) handleMqtt(ctx context.Context, pkt mqPkts.ControlPacket) err
 
 	// Client CONNECT transaction.
 	case *mqPkts.ConnackPacket:
-		transactionx, _ := h.transactions.GetByType(snPkts1.CONNECT)
+		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
 		transaction, ok := transactionx.(*connectTransaction)
 		if !ok {
 			h.log.Error("Unexpected transaction type %T for packet: %v", transactionx, mqPkt)
@@ -564,11 +565,11 @@ func (h *handler1) handleConnect(ctx context.Context, snConnect *snPkts1.Connect
 	}
 
 	// Cancel previous transaction, if any.
-	if oldTransaction, ok := h.transactions.GetByType(snPkts1.CONNECT); ok {
+	if oldTransaction, ok := h.transactions.GetByType(snPkts.CONNECT); ok {
 		oldTransaction.Fail(Cancelled)
 	}
 	transaction := newConnectTransaction(ctx, h, h.cfg.AuthEnabled, mqConnect)
-	h.transactions.StoreByType(snPkts1.CONNECT, transaction)
+	h.transactions.StoreByType(snPkts.CONNECT, transaction)
 	return transaction.Start(ctx)
 }
 
@@ -704,7 +705,7 @@ func (h *handler1) handleMqttSn(ctx context.Context, pkt snPkts1.Packet) error {
 
 	// Client CONNECT transaction.
 	case *snPkts1.Auth:
-		transactionx, _ := h.transactions.GetByType(snPkts1.CONNECT)
+		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
 		if transaction, ok := transactionx.(*connectTransaction); ok {
 			return transaction.Auth(snPkt)
 		}
@@ -713,7 +714,7 @@ func (h *handler1) handleMqttSn(ctx context.Context, pkt snPkts1.Packet) error {
 
 	// Client CONNECT transaction.
 	case *snPkts1.WillTopic:
-		transactionx, _ := h.transactions.GetByType(snPkts1.CONNECT)
+		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
 		if transaction, ok := transactionx.(*connectTransaction); ok {
 			return transaction.WillTopic(snPkt)
 		}
@@ -722,7 +723,7 @@ func (h *handler1) handleMqttSn(ctx context.Context, pkt snPkts1.Packet) error {
 
 	// Client CONNECT transaction.
 	case *snPkts1.WillMsg:
-		transactionx, _ := h.transactions.GetByType(snPkts1.CONNECT)
+		transactionx, _ := h.transactions.GetByType(snPkts.CONNECT)
 		if transaction, ok := transactionx.(*connectTransaction); ok {
 			return transaction.WillMsg(snPkt)
 		}
@@ -912,7 +913,7 @@ func (h *handler1) snReceive() (snPkts1.Packet, error) {
 	}
 
 	pktReader := bytes.NewReader(pktBuf)
-	header := &snPkts1.Header{}
+	header := &snPkts.Header{}
 	header.Unpack(pktReader)
 	pkt := snPkts1.NewPacketWithHeader(*header)
 	pkt.Unpack(pktReader)

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -303,7 +303,7 @@ func (h *handler1) handleBrokerPublish(ctx context.Context, mqPublish *mqPkts.Pu
 		// its MsgID is 0. We use a very dirty hack here to choose
 		// an "almost surely available" MsgID :(
 		found := false
-		for i := snPkts1.MaxMessageID; i >= snPkts1.MinMessageID; i-- {
+		for i := snPkts.MaxPacketID; i >= snPkts.MinPacketID; i-- {
 			if _, ok := h.transactions.Get(i); !ok {
 				msgID = i
 				found = true

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -104,7 +104,7 @@ func newHandler(cfg *handlerConfig, predefinedTopics topics.PredefinedTopics,
 		log:              logger,
 		state:            &state,
 		predefinedTopics: predefinedTopics,
-		topicID:          util.NewIDSequence(snPkts1.MinTopicID, snPkts1.MaxTopicID),
+		topicID:          util.NewIDSequence(snPkts.MinTopicAlias, snPkts.MaxTopicAlias),
 		transactions:     transactions.NewTransactionStore(),
 	}
 

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -247,7 +247,7 @@ func (h *handler1) handleClientPublish(ctx context.Context, snPublish *snPkts1.P
 			return fmt.Errorf("unknown topic id %d", snPublish.TopicID)
 		}
 	case snPkts1.TIT_SHORT:
-		topic = snPkts1.DecodeShortTopic(snPublish.TopicID)
+		topic = snPkts.DecodeShortTopic(snPublish.TopicID)
 	}
 	if snPublish.QOS == 1 {
 		h.transactions.Store(msgID, newClientPublishQOS1Transaction(ctx, h, msgID, snPublish.TopicID))
@@ -265,8 +265,8 @@ func (h *handler1) handleBrokerPublish(ctx context.Context, mqPublish *mqPkts.Pu
 	var needsRegister bool
 	var topicID uint16
 	var topicIDType uint8
-	if snPkts1.IsShortTopic(mqPublish.TopicName) {
-		topicID = snPkts1.EncodeShortTopic(mqPublish.TopicName)
+	if snPkts.IsShortTopic(mqPublish.TopicName) {
+		topicID = snPkts.EncodeShortTopic(mqPublish.TopicName)
 		topicIDType = snPkts1.TIT_SHORT
 		needsRegister = false
 	} else {
@@ -610,7 +610,7 @@ func (h *handler1) handleSubscribe(ctx context.Context, snSubscribe *snPkts1.Sub
 		}
 		topicID = snSubscribe.TopicID
 	case snPkts1.TIT_SHORT:
-		topic = snPkts1.DecodeShortTopic(snSubscribe.TopicID)
+		topic = snPkts.DecodeShortTopic(snSubscribe.TopicID)
 		// topicID remains zero.
 	}
 
@@ -638,7 +638,7 @@ func (h *handler1) handleUnsubscribe(snUnsubscribe *snPkts1.Unsubscribe) error {
 			return fmt.Errorf("unknown topic id %d", snUnsubscribe.TopicID)
 		}
 	case snPkts1.TIT_SHORT:
-		topic = snPkts1.DecodeShortTopic(snUnsubscribe.TopicID)
+		topic = snPkts.DecodeShortTopic(snUnsubscribe.TopicID)
 	}
 
 	mqUnsubscribe := mqPkts.NewControlPacket(mqPkts.Unsubscribe).(*mqPkts.UnsubscribePacket)

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -50,7 +50,7 @@ type handler1 struct {
 	keepAlive        uint16
 	clientID         string
 	topicID          *util.IDSequence
-	pktBuffer        []snPkts1.Packet
+	pktBuffer        []snPkts.Packet
 	group            *errgroup.Group
 	transactions     *transactions.TransactionStore
 	// for testing
@@ -327,7 +327,7 @@ func (h *handler1) handleBrokerPublish(ctx context.Context, mqPublish *mqPkts.Pu
 		return fmt.Errorf("invalid QoS in %v", mqPublish)
 	}
 
-	var snPkt snPkts1.Packet
+	var snPkt snPkts.Packet
 	var nextState transactionState
 	if needsRegister {
 		topicID, err := h.newTopicID()
@@ -656,7 +656,7 @@ func (h *handler1) handleUnsubscribe(snUnsubscribe *snPkts1.Unsubscribe) error {
 //    transactions. Also unexpected packets can be caused by delayed UDP
 //    packets etc. therefore we do not want to close the connection
 //    when such packet appears.
-func (h *handler1) checkPacketLegal(pkt snPkts1.Packet) error {
+func (h *handler1) checkPacketLegal(pkt snPkts.Packet) error {
 	state := h.state.Get()
 	if state != util.StateDisconnected {
 		return nil
@@ -692,7 +692,7 @@ func (h *handler1) checkPacketLegal(pkt snPkts1.Packet) error {
 	return ErrIllegalPacketWhenDisconnected
 }
 
-func (h *handler1) handleMqttSn(ctx context.Context, pkt snPkts1.Packet) error {
+func (h *handler1) handleMqttSn(ctx context.Context, pkt snPkts.Packet) error {
 	if err := h.checkPacketLegal(pkt); err != nil {
 		return err
 	}
@@ -879,7 +879,7 @@ func (h *handler1) startSleepPinger(ctx context.Context) context.CancelFunc {
 	return cancel
 }
 
-func (h *handler1) snSend(pkt snPkts1.Packet) error {
+func (h *handler1) snSend(pkt snPkts.Packet) error {
 	if h.state.Get() == util.StateAsleep {
 		h.log.Debug("Queued %v", pkt)
 		h.pktBuffer = append(h.pktBuffer, pkt)
@@ -895,7 +895,7 @@ func (h *handler1) snSend(pkt snPkts1.Packet) error {
 	return nil
 }
 
-func (h *handler1) snReceive() (snPkts1.Packet, error) {
+func (h *handler1) snReceive() (snPkts.Packet, error) {
 	// TODO: make static...
 	buffer := make([]byte, snPkts1.MaxPacketLen)
 

--- a/packets/packet_type.go
+++ b/packets/packet_type.go
@@ -1,0 +1,107 @@
+package packets
+
+import "fmt"
+
+// Packet type constants.
+type PacketType uint8
+
+const (
+	ADVERTISE     PacketType = 0x00
+	SEARCHGW      PacketType = 0x01
+	GWINFO        PacketType = 0x02
+	AUTH          PacketType = 0x03
+	CONNECT       PacketType = 0x04
+	CONNECT2      PacketType = 0x04
+	CONNACK       PacketType = 0x05
+	WILLTOPICREQ  PacketType = 0x06
+	WILLTOPIC     PacketType = 0x07
+	WILLMSGREQ    PacketType = 0x08
+	WILLMSG       PacketType = 0x09
+	REGISTER      PacketType = 0x0A
+	REGACK        PacketType = 0x0B
+	PUBLISH       PacketType = 0x0C
+	PUBACK        PacketType = 0x0D
+	PUBCOMP       PacketType = 0x0E
+	PUBREC        PacketType = 0x0F
+	PUBREL        PacketType = 0x10
+	SUBSCRIBE     PacketType = 0x12
+	SUBACK        PacketType = 0x13
+	UNSUBSCRIBE   PacketType = 0x14
+	UNSUBACK      PacketType = 0x15
+	PINGREQ       PacketType = 0x16
+	PINGRESP      PacketType = 0x17
+	DISCONNECT    PacketType = 0x18
+	WILLTOPICUPD  PacketType = 0x1A
+	WILLTOPICRESP PacketType = 0x1B
+	WILLMSGUPD    PacketType = 0x1C
+	WILLMSGRESP   PacketType = 0x1D
+	// 0x03 is reserved
+	// 0x11 is reserved
+	// 0x19 is reserved
+	// 0x1E - 0xFD is reserved
+	// 0xFE - Encapsulated message
+	// 0xFF is reserved
+)
+
+func (t PacketType) String() string {
+	switch t {
+	case ADVERTISE:
+		return "ADVERTISE"
+	case SEARCHGW:
+		return "SEARCHGW"
+	case GWINFO:
+		return "GWINFO"
+	case AUTH:
+		return "AUTH"
+	case CONNECT:
+		return "CONNECT"
+	case CONNACK:
+		return "CONNACK"
+	case WILLTOPICREQ:
+		return "WILLTOPICREQ"
+	case WILLTOPIC:
+		return "WILLTOPIC"
+	case WILLMSGREQ:
+		return "WILLMSGREQ"
+	case WILLMSG:
+		return "WILLMSG"
+	case REGISTER:
+		return "REGISTER"
+	case REGACK:
+		return "REGACK"
+	case PUBLISH:
+		return "PUBLISH"
+	case PUBACK:
+		return "PUBACK"
+	case PUBCOMP:
+		return "PUBCOMP"
+	case PUBREC:
+		return "PUBREC"
+	case PUBREL:
+		return "PUBREL"
+	case SUBSCRIBE:
+		return "SUBSCRIBE"
+	case SUBACK:
+		return "SUBACK"
+	case UNSUBSCRIBE:
+		return "UNSUBSCRIBE"
+	case UNSUBACK:
+		return "UNSUBACK"
+	case PINGREQ:
+		return "PINGREQ"
+	case PINGRESP:
+		return "PINGRESP"
+	case DISCONNECT:
+		return "DISCONNECT"
+	case WILLTOPICUPD:
+		return "WILLTOPICUPD"
+	case WILLTOPICRESP:
+		return "WILLTOPICRESP"
+	case WILLMSGUPD:
+		return "WILLMSGUPD"
+	case WILLMSGRESP:
+		return "WILLMSGRESP"
+	default:
+		return fmt.Sprintf("unknown (%d)", t)
+	}
+}

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -19,3 +19,13 @@ type Packet interface {
 	//  disappears.
 	SetVarPartLength(uint16)
 }
+
+// Packet ID range.
+// We intentionally do not use pktID=0. The MQTT-SN specification does
+// not forbid it but uses 0 as an "empty, not used" value.
+// I suppose, it's better to not use it to be very explicit about that
+// the value really _is_ important if it's non-zero.
+const (
+	MinPacketID uint16 = 1
+	MaxPacketID uint16 = 0xFFFF
+)

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -1,0 +1,21 @@
+package packets
+
+import (
+	"fmt"
+	"io"
+)
+
+type Packet interface {
+	fmt.Stringer
+
+	Write(io.Writer) error
+	Unpack(io.Reader) error
+
+	// NOTE: This method is not used anywhere but we must temporary keep it
+	// here because if we remove it, MQTT packets would accidently implement
+	// this interface and we would not be able to type-switch between MQTT
+	// and MQTT-SN packets.
+	// TODO: Remove as soon as this interface is changed and this problem
+	//  disappears.
+	SetVarPartLength(uint16)
+}

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -29,3 +29,12 @@ const (
 	MinPacketID uint16 = 1
 	MaxPacketID uint16 = 0xFFFF
 )
+
+// Topic Alias range.
+// The values `0x0000` and `0xFFFF` are reserved and therefore should not be used.
+//
+// See MQTT-SN specification v. 1.2, chapter 5.3.11.
+const (
+	MinTopicAlias uint16 = 1
+	MaxTopicAlias uint16 = 0xFFFF - 1
+)

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -1,6 +1,7 @@
 package packets
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 )
@@ -38,3 +39,36 @@ const (
 	MinTopicAlias uint16 = 1
 	MaxTopicAlias uint16 = 0xFFFF - 1
 )
+
+// IsShortTopic determines if the given topic is a short topic.
+//
+// See MQTT-SN specification v. 1.2, chapter 3 MQTT-SN vs MQTT.
+func IsShortTopic(topic string) bool {
+	return len(topic) == 2
+}
+
+// EncodeShortTopic encodes a short string topic into TopicID (uint16).
+//
+// See MQTT-SN specification v. 1.2, chapter 3 MQTT-SN vs MQTT.
+func EncodeShortTopic(topic string) uint16 {
+	var result uint16
+
+	bytes := []byte(topic)
+	if len(bytes) > 0 {
+		result |= (uint16(bytes[0]) << 8)
+	}
+	if len(bytes) > 1 {
+		result |= uint16(bytes[1])
+	}
+
+	return result
+}
+
+// DecodeShortTopic decodes a short string topic from TopicID (uint16).
+//
+// See MQTT-SN specification v. 1.2, chapter 3 MQTT-SN vs MQTT.
+func DecodeShortTopic(topicAlias uint16) string {
+	bytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(bytes, topicAlias)
+	return string(bytes)
+}

--- a/packets/property_dup.go
+++ b/packets/property_dup.go
@@ -1,7 +1,13 @@
-package packets1
+package packets
 
 type DUPProperty struct {
 	dup bool
+}
+
+func NewDUPProperty(dup bool) *DUPProperty {
+	return &DUPProperty{
+		dup: dup,
+	}
 }
 
 func (p *DUPProperty) SetDUP(dup bool) {

--- a/packets1/advertise.go
+++ b/packets1/advertise.go
@@ -3,39 +3,41 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const advertiseVarPartLength uint16 = 3
 
 type Advertise struct {
-	Header
+	pkts.Header
 	GatewayID uint8
 	Duration  uint16
 }
 
 func NewAdvertise(gatewayID uint8, duration uint16) *Advertise {
 	return &Advertise{
-		Header:    *NewHeader(ADVERTISE, advertiseVarPartLength),
+		Header:    *pkts.NewHeader(pkts.ADVERTISE, advertiseVarPartLength),
 		GatewayID: gatewayID,
 		Duration:  duration,
 	}
 }
 
 func (p *Advertise) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.GatewayID)
-	buf.Write(encodeUint16(p.Duration))
+	buf.Write(pkts.EncodeUint16(p.Duration))
 
 	_, err := buf.WriteTo(w)
 	return err
 }
 
 func (p *Advertise) Unpack(r io.Reader) (err error) {
-	if p.GatewayID, err = readByte(r); err != nil {
+	if p.GatewayID, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 
-	p.Duration, err = readUint16(r)
+	p.Duration, err = pkts.ReadUint16(r)
 	return
 }
 

--- a/packets1/auth.go
+++ b/packets1/auth.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 // Authentication reason constants.
@@ -25,7 +27,7 @@ const (
 //
 // SASL PLAIN method specification: https://datatracker.ietf.org/doc/html/rfc4616
 type Auth struct {
-	Header
+	pkts.Header
 	Reason uint8
 	Method string
 	Data   []byte
@@ -34,7 +36,7 @@ type Auth struct {
 // NewAuthPlain creates a new Auth with "PLAIN" method encoded
 // authentication data.
 func NewAuthPlain(user string, password []byte) *Auth {
-	auth := &Auth{Header: *NewHeader(AUTH, 0)}
+	auth := &Auth{Header: *pkts.NewHeader(pkts.AUTH, 0)}
 	auth.Method = "PLAIN"
 	var b bytes.Buffer
 	b.Write([]byte{0})
@@ -59,7 +61,7 @@ func DecodePlain(auth *Auth) (string, []byte, error) {
 }
 
 func (p *Auth) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.Reason)
 	buf.WriteByte(byte(len(p.Method)))
 	buf.Write([]byte(p.Method))
@@ -70,12 +72,12 @@ func (p *Auth) Write(w io.Writer) error {
 }
 
 func (p *Auth) Unpack(r io.Reader) (err error) {
-	if p.Reason, err = readByte(r); err != nil {
+	if p.Reason, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 
 	var methodLen uint8
-	if methodLen, err = readByte(r); err != nil {
+	if methodLen, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 	method := make([]byte, methodLen)

--- a/packets1/connack.go
+++ b/packets1/connack.go
@@ -3,24 +3,26 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const connackVarPartLength uint16 = 1
 
 type Connack struct {
-	Header
+	pkts.Header
 	ReturnCode ReturnCode
 }
 
 func NewConnack(returnCode ReturnCode) *Connack {
 	return &Connack{
-		Header:     *NewHeader(CONNACK, connackVarPartLength),
+		Header:     *pkts.NewHeader(pkts.CONNACK, connackVarPartLength),
 		ReturnCode: returnCode,
 	}
 }
 
 func (p *Connack) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(byte(p.ReturnCode))
 
 	_, err := buf.WriteTo(w)
@@ -29,7 +31,7 @@ func (p *Connack) Write(w io.Writer) error {
 
 func (p *Connack) Unpack(r io.Reader) (err error) {
 	var returnCodeByte uint8
-	returnCodeByte, err = readByte(r)
+	returnCodeByte, err = pkts.ReadByte(r)
 	p.ReturnCode = ReturnCode(returnCodeByte)
 	return
 }

--- a/packets1/connect.go
+++ b/packets1/connect.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const connectHeaderLength uint16 = 4
 
 type Connect struct {
-	Header
+	pkts.Header
 	CleanSession bool
 	ClientID     []byte
 	Duration     uint16
@@ -19,7 +21,7 @@ type Connect struct {
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewConnect(clientID []byte, cleanSession bool, will bool, duration uint16) *Connect {
 	p := &Connect{
-		Header:       *NewHeader(CONNECT, 0),
+		Header:       *pkts.NewHeader(pkts.CONNECT, 0),
 		Will:         will,
 		CleanSession: cleanSession,
 		ProtocolID:   0x01,
@@ -54,10 +56,10 @@ func (p *Connect) encodeFlags() byte {
 func (p *Connect) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.encodeFlags())
 	buf.WriteByte(p.ProtocolID)
-	buf.Write(encodeUint16(p.Duration))
+	buf.Write(pkts.EncodeUint16(p.Duration))
 	buf.Write([]byte(p.ClientID))
 
 	_, err := buf.WriteTo(w)
@@ -66,16 +68,16 @@ func (p *Connect) Write(w io.Writer) error {
 
 func (p *Connect) Unpack(r io.Reader) (err error) {
 	var flagsByte uint8
-	if flagsByte, err = readByte(r); err != nil {
+	if flagsByte, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 	p.decodeFlags(flagsByte)
 
-	if p.ProtocolID, err = readByte(r); err != nil {
+	if p.ProtocolID, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 
-	if p.Duration, err = readUint16(r); err != nil {
+	if p.Duration, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 

--- a/packets1/disconnect.go
+++ b/packets1/disconnect.go
@@ -3,19 +3,21 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const disconnectDurationLength uint16 = 2
 
 type Disconnect struct {
-	Header
+	pkts.Header
 	Duration uint16
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewDisconnect(duration uint16) *Disconnect {
 	p := &Disconnect{
-		Header:   *NewHeader(DISCONNECT, 0),
+		Header:   *pkts.NewHeader(pkts.DISCONNECT, 0),
 		Duration: duration,
 	}
 	p.computeLength()
@@ -37,9 +39,9 @@ func (p *Disconnect) computeLength() {
 func (p *Disconnect) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	if p.VarPartLength() > 0 {
-		buf.Write(encodeUint16(p.Duration))
+		buf.Write(pkts.EncodeUint16(p.Duration))
 	}
 
 	_, err := buf.WriteTo(w)
@@ -48,7 +50,7 @@ func (p *Disconnect) Write(w io.Writer) error {
 
 func (p *Disconnect) Unpack(r io.Reader) (err error) {
 	if p.VarPartLength() == disconnectDurationLength {
-		p.Duration, err = readUint16(r)
+		p.Duration, err = pkts.ReadUint16(r)
 	} else {
 		p.Duration = 0
 	}

--- a/packets1/gwinfo.go
+++ b/packets1/gwinfo.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const gwInfoHeaderLength uint16 = 1
 
 type GwInfo struct {
-	Header
+	pkts.Header
 	GatewayID      uint8
 	GatewayAddress []byte
 }
@@ -16,7 +18,7 @@ type GwInfo struct {
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewGwInfo(gatewayID uint8, gatewayAddress []byte) *GwInfo {
 	p := &GwInfo{
-		Header:         *NewHeader(GWINFO, 0),
+		Header:         *pkts.NewHeader(pkts.GWINFO, 0),
 		GatewayID:      gatewayID,
 		GatewayAddress: gatewayAddress,
 	}
@@ -32,7 +34,7 @@ func (p *GwInfo) computeLength() {
 func (p *GwInfo) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.GatewayID)
 	buf.Write(p.GatewayAddress)
 
@@ -41,7 +43,7 @@ func (p *GwInfo) Write(w io.Writer) error {
 }
 
 func (p *GwInfo) Unpack(r io.Reader) (err error) {
-	if p.GatewayID, err = readByte(r); err != nil {
+	if p.GatewayID, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 

--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -69,16 +69,6 @@ func (c ReturnCode) String() string {
 	}
 }
 
-// Message ID range.
-// We intentionally do not use msgID=0. The MQTT-SN specification does
-// not forbid it but uses 0 as an "empty, not used" value.
-// I suppose, it's better to not use it to be very explicit about that
-// the value really _is_ important if it's non-zero.
-const (
-	MinMessageID uint16 = 1
-	MaxMessageID uint16 = 0xFFFF
-)
-
 // Topic ID range.
 // The values `0x0000` and `0xFFFF` are reserved and therefore should not be used.
 //

--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -151,37 +151,6 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet) {
 	return
 }
 
-// IsShortTopic determines if the given topic is a short topic.
-//
-// See MQTT-SN specification v. 1.2, chapter 3 MQTT-SN vs MQTT.
-func IsShortTopic(topic string) bool {
-	return len(topic) == 2
-}
-
-// EncodeShortTopic encodes a short string topic into TopicID (uint16).
-//
-// See MQTT-SN specification v. 1.2, chapter 3 MQTT-SN vs MQTT.
-func EncodeShortTopic(topic string) uint16 {
-	var result uint16
-
-	bytes := []byte(topic)
-	if len(bytes) > 0 {
-		result |= (uint16(bytes[0]) << 8)
-	}
-	if len(bytes) > 1 {
-		result |= uint16(bytes[1])
-	}
-
-	return result
-}
-
-// DecodeShortTopic decodes a short string topic from TopicID (uint16).
-//
-// See MQTT-SN specification v. 1.2, chapter 3 MQTT-SN vs MQTT.
-func DecodeShortTopic(topicID uint16) string {
-	return string(pkts.EncodeUint16(topicID))
-}
-
 // Flags bit mask constants.
 const (
 	flagsTopicIDTypeBits = 0x03

--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -69,15 +69,6 @@ func (c ReturnCode) String() string {
 	}
 }
 
-// Topic ID range.
-// The values `0x0000` and `0xFFFF` are reserved and therefore should not be used.
-//
-// See MQTT-SN specification v. 1.2, chapter 5.3.11.
-const (
-	MinTopicID uint16 = 1
-	MaxTopicID uint16 = 0xFFFF - 1
-)
-
 // ReadPacket reads an MQTT-SN packet from the given io.Reader.
 func ReadPacket(r io.Reader) (pkt pkts.Packet, err error) {
 	var h pkts.Header

--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -34,21 +34,6 @@ const MaxPacketLen = 8192
 // this arbitrary "small enough to be safe" maximal payload length.
 const MaxPayloadLength = 7168
 
-type Packet interface {
-	fmt.Stringer
-
-	Write(io.Writer) error
-	Unpack(io.Reader) error
-
-	// NOTE: This method is not used anywhere but we must temporary keep it
-	// here because if we remove it, MQTT packets would accidently implement
-	// this interface and we would not be able to type-switch between MQTT
-	// and MQTT-SN packets.
-	// TODO: Remove as soon as this interface is changed and this problem
-	//  disappears.
-	SetVarPartLength(uint16)
-}
-
 // TopicID type constants.
 const (
 	TIT_REGISTERED uint8 = iota
@@ -104,7 +89,7 @@ const (
 )
 
 // ReadPacket reads an MQTT-SN packet from the given io.Reader.
-func ReadPacket(r io.Reader) (pkt Packet, err error) {
+func ReadPacket(r io.Reader) (pkt pkts.Packet, err error) {
 	var h pkts.Header
 	packet := make([]byte, MaxPacketLen)
 	n, err := r.Read(packet)
@@ -123,7 +108,7 @@ func ReadPacket(r io.Reader) (pkt Packet, err error) {
 
 // NewPacketWithHeader returns a particular packet struct with a given header.
 // The struct type is determined by h.msgType.
-func NewPacketWithHeader(h pkts.Header) (pkt Packet) {
+func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet) {
 	switch h.PacketType() {
 	case pkts.ADVERTISE:
 		pkt = &Advertise{Header: h}

--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -35,10 +35,18 @@ const MaxPacketLen = 8192
 const MaxPayloadLength = 7168
 
 type Packet interface {
-	SetVarPartLength(uint16)
+	fmt.Stringer
+
 	Write(io.Writer) error
 	Unpack(io.Reader) error
-	String() string
+
+	// NOTE: This method is not used anywhere but we must temporary keep it
+	// here because if we remove it, MQTT packets would accidently implement
+	// this interface and we would not be able to type-switch between MQTT
+	// and MQTT-SN packets.
+	// TODO: Remove as soon as this interface is changed and this problem
+	//  disappears.
+	SetVarPartLength(uint16)
 }
 
 // TopicID type constants.

--- a/packets1/pingreq.go
+++ b/packets1/pingreq.go
@@ -3,17 +3,19 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 type Pingreq struct {
-	Header
+	pkts.Header
 	ClientID []byte
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewPingreq(clientID []byte) *Pingreq {
 	p := &Pingreq{
-		Header:   *NewHeader(PINGREQ, 0),
+		Header:   *pkts.NewHeader(pkts.PINGREQ, 0),
 		ClientID: clientID,
 	}
 	p.computeLength()
@@ -28,7 +30,7 @@ func (p *Pingreq) computeLength() {
 func (p *Pingreq) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	if len(p.ClientID) > 0 {
 		buf.Write(p.ClientID)
 	}

--- a/packets1/pingresp.go
+++ b/packets1/pingresp.go
@@ -2,22 +2,24 @@ package packets1
 
 import (
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const pingrespVarPartLength uint16 = 0
 
 type Pingresp struct {
-	Header
+	pkts.Header
 }
 
 func NewPingresp() *Pingresp {
 	return &Pingresp{
-		Header: *NewHeader(PINGRESP, pingrespVarPartLength),
+		Header: *pkts.NewHeader(pkts.PINGRESP, pingrespVarPartLength),
 	}
 }
 
 func (p *Pingresp) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 
 	_, err := buf.WriteTo(w)
 	return err

--- a/packets1/puback.go
+++ b/packets1/puback.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const pubackVarPartLength uint16 = 5
 
 type Puback struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 	TopicID    uint16
 	ReturnCode ReturnCode
@@ -16,16 +18,16 @@ type Puback struct {
 
 func NewPuback(topicID uint16, returnCode ReturnCode) *Puback {
 	return &Puback{
-		Header:     *NewHeader(PUBACK, pubackVarPartLength),
+		Header:     *pkts.NewHeader(pkts.PUBACK, pubackVarPartLength),
 		TopicID:    topicID,
 		ReturnCode: returnCode,
 	}
 }
 
 func (p *Puback) Write(w io.Writer) error {
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.TopicID))
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.TopicID))
+	buf.Write(pkts.EncodeUint16(p.messageID))
 	buf.WriteByte(byte(p.ReturnCode))
 
 	_, err := buf.WriteTo(w)
@@ -33,16 +35,16 @@ func (p *Puback) Write(w io.Writer) error {
 }
 
 func (p *Puback) Unpack(r io.Reader) (err error) {
-	if p.TopicID, err = readUint16(r); err != nil {
+	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 
-	if p.messageID, err = readUint16(r); err != nil {
+	if p.messageID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 
 	var returnCodeByte uint8
-	returnCodeByte, err = readByte(r)
+	returnCodeByte, err = pkts.ReadByte(r)
 	p.ReturnCode = ReturnCode(returnCodeByte)
 	return
 }

--- a/packets1/pubcomp.go
+++ b/packets1/pubcomp.go
@@ -3,31 +3,33 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const pubcompVarPartLength uint16 = 2
 
 type Pubcomp struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 }
 
 func NewPubcomp() *Pubcomp {
 	return &Pubcomp{
-		Header: *NewHeader(PUBCOMP, pubcompVarPartLength),
+		Header: *pkts.NewHeader(pkts.PUBCOMP, pubcompVarPartLength),
 	}
 }
 
 func (p *Pubcomp) Write(w io.Writer) error {
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.messageID))
 
 	_, err := buf.WriteTo(w)
 	return err
 }
 
 func (p *Pubcomp) Unpack(r io.Reader) (err error) {
-	p.messageID, err = readUint16(r)
+	p.messageID, err = pkts.ReadUint16(r)
 	return
 }
 

--- a/packets1/publish.go
+++ b/packets1/publish.go
@@ -12,7 +12,7 @@ const publishHeaderLength uint16 = 5
 type Publish struct {
 	pkts.Header
 	MessageIDProperty
-	DUPProperty
+	pkts.DUPProperty
 	Retain      bool
 	QOS         uint8
 	TopicIDType uint8
@@ -24,8 +24,8 @@ type Publish struct {
 func NewPublish(topicID uint16, topicIDType uint8, payload []byte, qos uint8,
 	retain bool, dup bool) *Publish {
 	p := &Publish{
-		DUPProperty: DUPProperty{dup},
 		Header:      *pkts.NewHeader(pkts.PUBLISH, 0),
+		DUPProperty: *pkts.NewDUPProperty(dup),
 		TopicID:     topicID,
 		TopicIDType: topicIDType,
 		Data:        payload,
@@ -43,7 +43,7 @@ func (p *Publish) computeLength() {
 
 func (p *Publish) encodeFlags() byte {
 	var b byte
-	if p.dup {
+	if p.DUP() {
 		b |= flagsDUPBit
 	}
 	b |= (p.QOS << 5) & flagsQOSBits
@@ -55,7 +55,7 @@ func (p *Publish) encodeFlags() byte {
 }
 
 func (p *Publish) decodeFlags(b byte) {
-	p.dup = (b & flagsDUPBit) == flagsDUPBit
+	p.SetDUP((b & flagsDUPBit) == flagsDUPBit)
 	p.QOS = (b & flagsQOSBits) >> 5
 	p.Retain = (b & flagsRetainBit) == flagsRetainBit
 	p.TopicIDType = b & flagsTopicIDTypeBits
@@ -105,5 +105,5 @@ func (p Publish) String() string {
 		topicIDType = "s"
 	}
 	return fmt.Sprintf("PUBLISH(TopicID(%s)=%d, Data=%#v, QOS=%d, Retain=%t, MessageID=%d, Dup=%t)",
-		topicIDType, p.TopicID, string(p.Data), p.QOS, p.Retain, p.messageID, p.dup)
+		topicIDType, p.TopicID, string(p.Data), p.QOS, p.Retain, p.messageID, p.DUP())
 }

--- a/packets1/publish.go
+++ b/packets1/publish.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const publishHeaderLength uint16 = 5
 
 type Publish struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 	DUPProperty
 	Retain      bool
@@ -22,8 +24,8 @@ type Publish struct {
 func NewPublish(topicID uint16, topicIDType uint8, payload []byte, qos uint8,
 	retain bool, dup bool) *Publish {
 	p := &Publish{
-		Header:      *NewHeader(PUBLISH, 0),
 		DUPProperty: DUPProperty{dup},
+		Header:      *pkts.NewHeader(pkts.PUBLISH, 0),
 		TopicID:     topicID,
 		TopicIDType: topicIDType,
 		Data:        payload,
@@ -62,10 +64,10 @@ func (p *Publish) decodeFlags(b byte) {
 func (p *Publish) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.encodeFlags())
-	buf.Write(encodeUint16(p.TopicID))
-	buf.Write(encodeUint16(p.messageID))
+	buf.Write(pkts.EncodeUint16(p.TopicID))
+	buf.Write(pkts.EncodeUint16(p.messageID))
 	buf.Write(p.Data)
 
 	_, err := buf.WriteTo(w)
@@ -74,16 +76,16 @@ func (p *Publish) Write(w io.Writer) error {
 
 func (p *Publish) Unpack(r io.Reader) (err error) {
 	var flagsByte uint8
-	if flagsByte, err = readByte(r); err != nil {
+	if flagsByte, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 	p.decodeFlags(flagsByte)
 
-	if p.TopicID, err = readUint16(r); err != nil {
+	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 
-	if p.messageID, err = readUint16(r); err != nil {
+	if p.messageID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 

--- a/packets1/pubrec.go
+++ b/packets1/pubrec.go
@@ -3,31 +3,33 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const pubrecVarPartLength uint16 = 2
 
 type Pubrec struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 }
 
 func NewPubrec() *Pubrec {
 	return &Pubrec{
-		Header: *NewHeader(PUBREC, pubrecVarPartLength),
+		Header: *pkts.NewHeader(pkts.PUBREC, pubrecVarPartLength),
 	}
 }
 
 func (p *Pubrec) Write(w io.Writer) error {
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.messageID))
 
 	_, err := buf.WriteTo(w)
 	return err
 }
 
 func (p *Pubrec) Unpack(r io.Reader) (err error) {
-	p.messageID, err = readUint16(r)
+	p.messageID, err = pkts.ReadUint16(r)
 	return
 }
 

--- a/packets1/pubrel.go
+++ b/packets1/pubrel.go
@@ -3,31 +3,33 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const pubrelVarPartLength uint16 = 2
 
 type Pubrel struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 }
 
 func NewPubrel() *Pubrel {
 	return &Pubrel{
-		Header: *NewHeader(PUBREL, pubrelVarPartLength),
+		Header: *pkts.NewHeader(pkts.PUBREL, pubrelVarPartLength),
 	}
 }
 
 func (p *Pubrel) Write(w io.Writer) error {
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.messageID))
 
 	_, err := buf.WriteTo(w)
 	return err
 }
 
 func (p *Pubrel) Unpack(r io.Reader) (err error) {
-	p.messageID, err = readUint16(r)
+	p.messageID, err = pkts.ReadUint16(r)
 	return
 }
 

--- a/packets1/regack.go
+++ b/packets1/regack.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const regackVarPartLength uint16 = 5
 
 type Regack struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 	TopicID    uint16
 	ReturnCode ReturnCode
@@ -16,16 +18,16 @@ type Regack struct {
 
 func NewRegack(topicID uint16, returnCode ReturnCode) *Regack {
 	return &Regack{
-		Header:     *NewHeader(REGACK, regackVarPartLength),
+		Header:     *pkts.NewHeader(pkts.REGACK, regackVarPartLength),
 		TopicID:    topicID,
 		ReturnCode: returnCode,
 	}
 }
 
 func (p *Regack) Write(w io.Writer) error {
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.TopicID))
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.TopicID))
+	buf.Write(pkts.EncodeUint16(p.messageID))
 	buf.WriteByte(byte(p.ReturnCode))
 
 	_, err := buf.WriteTo(w)
@@ -33,14 +35,14 @@ func (p *Regack) Write(w io.Writer) error {
 }
 
 func (p *Regack) Unpack(r io.Reader) (err error) {
-	if p.TopicID, err = readUint16(r); err != nil {
+	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
-	if p.messageID, err = readUint16(r); err != nil {
+	if p.messageID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 	var returnCodeByte uint8
-	returnCodeByte, err = readByte(r)
+	returnCodeByte, err = pkts.ReadByte(r)
 	p.ReturnCode = ReturnCode(returnCodeByte)
 	return
 }

--- a/packets1/register.go
+++ b/packets1/register.go
@@ -3,12 +3,15 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	"github.com/energomonitor/bisquitt/packets"
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const registerHeaderLength uint16 = 4
 
 type Register struct {
-	Header
+	packets.Header
 	MessageIDProperty
 	TopicID   uint16
 	TopicName string
@@ -17,7 +20,7 @@ type Register struct {
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewRegister(topicID uint16, topicName string) *Register {
 	p := &Register{
-		Header:    *NewHeader(REGISTER, 0),
+		Header:    *pkts.NewHeader(pkts.REGISTER, 0),
 		TopicID:   topicID,
 		TopicName: topicName,
 	}
@@ -33,9 +36,9 @@ func (p *Register) computeLength() {
 func (p *Register) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.TopicID))
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.TopicID))
+	buf.Write(pkts.EncodeUint16(p.messageID))
 	buf.Write([]byte(p.TopicName))
 
 	_, err := buf.WriteTo(w)
@@ -43,11 +46,11 @@ func (p *Register) Write(w io.Writer) error {
 }
 
 func (p *Register) Unpack(r io.Reader) (err error) {
-	if p.TopicID, err = readUint16(r); err != nil {
+	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 
-	if p.messageID, err = readUint16(r); err != nil {
+	if p.messageID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 

--- a/packets1/searchgw.go
+++ b/packets1/searchgw.go
@@ -3,24 +3,26 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const searchGwVarPartLength uint16 = 1
 
 type SearchGw struct {
-	Header
+	pkts.Header
 	Radius uint8
 }
 
 func NewSearchGw(radius uint8) *SearchGw {
 	return &SearchGw{
-		Header: *NewHeader(SEARCHGW, searchGwVarPartLength),
+		Header: *pkts.NewHeader(pkts.SEARCHGW, searchGwVarPartLength),
 		Radius: radius,
 	}
 }
 
 func (p *SearchGw) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.Radius)
 
 	_, err := buf.WriteTo(w)
@@ -28,7 +30,7 @@ func (p *SearchGw) Write(w io.Writer) error {
 }
 
 func (p *SearchGw) Unpack(r io.Reader) (err error) {
-	p.Radius, err = readByte(r)
+	p.Radius, err = pkts.ReadByte(r)
 	return
 }
 

--- a/packets1/suback.go
+++ b/packets1/suback.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const subackVarPartLength uint16 = 6
 
 type Suback struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 	QOS        uint8
 	ReturnCode ReturnCode
@@ -17,7 +19,7 @@ type Suback struct {
 
 func NewSuback(topicID uint16, qos uint8, returnCode ReturnCode) *Suback {
 	return &Suback{
-		Header:     *NewHeader(SUBACK, subackVarPartLength),
+		Header:     *pkts.NewHeader(pkts.SUBACK, subackVarPartLength),
 		QOS:        qos,
 		ReturnCode: returnCode,
 		TopicID:    topicID,
@@ -35,10 +37,10 @@ func (p *Suback) decodeFlags(b byte) {
 }
 
 func (p *Suback) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.encodeFlags())
-	buf.Write(encodeUint16(p.TopicID))
-	buf.Write(encodeUint16(p.messageID))
+	buf.Write(pkts.EncodeUint16(p.TopicID))
+	buf.Write(pkts.EncodeUint16(p.messageID))
 	buf.WriteByte(byte(p.ReturnCode))
 
 	_, err := buf.WriteTo(w)
@@ -47,21 +49,21 @@ func (p *Suback) Write(w io.Writer) error {
 
 func (p *Suback) Unpack(r io.Reader) (err error) {
 	var flagsByte uint8
-	if flagsByte, err = readByte(r); err != nil {
+	if flagsByte, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 	p.decodeFlags(flagsByte)
 
-	if p.TopicID, err = readUint16(r); err != nil {
+	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 
-	if p.messageID, err = readUint16(r); err != nil {
+	if p.messageID, err = pkts.ReadUint16(r); err != nil {
 		return
 	}
 
 	var returnCodeByte uint8
-	returnCodeByte, err = readByte(r)
+	returnCodeByte, err = pkts.ReadByte(r)
 	p.ReturnCode = ReturnCode(returnCodeByte)
 	return
 }

--- a/packets1/subscribe.go
+++ b/packets1/subscribe.go
@@ -10,8 +10,8 @@ import (
 const subscribeHeaderLength uint16 = 3
 
 type Subscribe struct {
-	DUPProperty
 	pkts.Header
+	pkts.DUPProperty
 	MessageIDProperty
 	QOS         uint8
 	TopicIDType uint8
@@ -22,8 +22,8 @@ type Subscribe struct {
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewSubscribe(topicID uint16, topicIDType uint8, topicName []byte, qos uint8, dup bool) *Subscribe {
 	p := &Subscribe{
-		DUPProperty: DUPProperty{dup},
 		Header:      *pkts.NewHeader(pkts.SUBSCRIBE, 0),
+		DUPProperty: *pkts.NewDUPProperty(dup),
 		QOS:         qos,
 		TopicIDType: topicIDType,
 		TopicID:     topicID,
@@ -46,7 +46,7 @@ func (p *Subscribe) computeLength() {
 
 func (p *Subscribe) encodeFlags() byte {
 	var b byte
-	if p.dup {
+	if p.DUP() {
 		b |= flagsDUPBit
 	}
 	b |= (p.QOS << 5) & flagsQOSBits
@@ -55,7 +55,7 @@ func (p *Subscribe) encodeFlags() byte {
 }
 
 func (p *Subscribe) decodeFlags(b byte) {
-	p.dup = (b & flagsDUPBit) == flagsDUPBit
+	p.SetDUP((b & flagsDUPBit) == flagsDUPBit)
 	p.QOS = (b & flagsQOSBits) >> 5
 	p.TopicIDType = b & flagsTopicIDTypeBits
 }
@@ -104,5 +104,5 @@ func (p *Subscribe) Unpack(r io.Reader) (err error) {
 
 func (p Subscribe) String() string {
 	return fmt.Sprintf("SUBSCRIBE(TopicName=%#v, QOS=%d, TopicID=%d, TopicIDType=%d, MessageID=%d, Dup=%t)",
-		string(p.TopicName), p.QOS, p.TopicID, p.TopicIDType, p.messageID, p.dup)
+		string(p.TopicName), p.QOS, p.TopicID, p.TopicIDType, p.messageID, p.DUP())
 }

--- a/packets1/unsuback.go
+++ b/packets1/unsuback.go
@@ -3,31 +3,33 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const unsubackVarPartLength uint16 = 2
 
 type Unsuback struct {
-	Header
+	pkts.Header
 	MessageIDProperty
 }
 
 func NewUnsuback() *Unsuback {
 	return &Unsuback{
-		Header: *NewHeader(UNSUBACK, unsubackVarPartLength),
+		Header: *pkts.NewHeader(pkts.UNSUBACK, unsubackVarPartLength),
 	}
 }
 
 func (p *Unsuback) Write(w io.Writer) error {
-	buf := p.Header.pack()
-	buf.Write(encodeUint16(p.messageID))
+	buf := p.Header.Pack()
+	buf.Write(pkts.EncodeUint16(p.messageID))
 
 	_, err := buf.WriteTo(w)
 	return err
 }
 
 func (p *Unsuback) Unpack(r io.Reader) (err error) {
-	p.messageID, err = readUint16(r)
+	p.messageID, err = pkts.ReadUint16(r)
 	return
 }
 

--- a/packets1/willmsg.go
+++ b/packets1/willmsg.go
@@ -3,17 +3,19 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 type WillMsg struct {
-	Header
+	pkts.Header
 	WillMsg []byte
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewWillMsg(willMsg []byte) *WillMsg {
 	p := &WillMsg{
-		Header:  *NewHeader(WILLMSG, 0),
+		Header:  *pkts.NewHeader(pkts.WILLMSG, 0),
 		WillMsg: willMsg,
 	}
 	p.computeLength()
@@ -28,7 +30,7 @@ func (p *WillMsg) computeLength() {
 func (p *WillMsg) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.Write(p.WillMsg)
 
 	_, err := buf.WriteTo(w)

--- a/packets1/willmsgreq.go
+++ b/packets1/willmsgreq.go
@@ -2,22 +2,24 @@ package packets1
 
 import (
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const willMsgReqVarPartLength uint16 = 0
 
 type WillMsgReq struct {
-	Header
+	pkts.Header
 }
 
 func NewWillMsgReq() *WillMsgReq {
 	return &WillMsgReq{
-		Header: *NewHeader(WILLMSGREQ, willMsgReqVarPartLength),
+		Header: *pkts.NewHeader(pkts.WILLMSGREQ, willMsgReqVarPartLength),
 	}
 }
 
 func (p *WillMsgReq) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 
 	_, err := buf.WriteTo(w)
 	return err

--- a/packets1/willmsgresp.go
+++ b/packets1/willmsgresp.go
@@ -3,24 +3,26 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const willMsgRespVarPartLength uint16 = 1
 
 type WillMsgResp struct {
-	Header
+	pkts.Header
 	ReturnCode ReturnCode
 }
 
 func NewWillMsgResp(returnCode ReturnCode) *WillMsgResp {
 	return &WillMsgResp{
-		Header:     *NewHeader(WILLMSGRESP, willMsgRespVarPartLength),
+		Header:     *pkts.NewHeader(pkts.WILLMSGRESP, willMsgRespVarPartLength),
 		ReturnCode: returnCode,
 	}
 }
 
 func (p *WillMsgResp) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(byte(p.ReturnCode))
 
 	_, err := buf.WriteTo(w)
@@ -29,7 +31,7 @@ func (p *WillMsgResp) Write(w io.Writer) error {
 
 func (p *WillMsgResp) Unpack(r io.Reader) (err error) {
 	var returnCodeByte uint8
-	returnCodeByte, err = readByte(r)
+	returnCodeByte, err = pkts.ReadByte(r)
 	p.ReturnCode = ReturnCode(returnCodeByte)
 	return
 }

--- a/packets1/willmsgupd.go
+++ b/packets1/willmsgupd.go
@@ -3,17 +3,19 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 type WillMsgUpdate struct {
-	Header
+	pkts.Header
 	WillMsg []byte
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewWillMsgUpdate(willMsg []byte) *WillMsgUpdate {
 	p := &WillMsgUpdate{
-		Header:  *NewHeader(WILLMSGUPD, 0),
+		Header:  *pkts.NewHeader(pkts.WILLMSGUPD, 0),
 		WillMsg: willMsg,
 	}
 	p.computeLength()
@@ -28,7 +30,7 @@ func (p *WillMsgUpdate) computeLength() {
 func (p *WillMsgUpdate) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.Write(p.WillMsg)
 
 	_, err := buf.WriteTo(w)

--- a/packets1/willtopic.go
+++ b/packets1/willtopic.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const willTopicFlagsLength uint16 = 1
 
 type WillTopic struct {
-	Header
+	pkts.Header
 	QOS       uint8
 	Retain    bool
 	WillTopic string
@@ -17,7 +19,7 @@ type WillTopic struct {
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewWillTopic(willTopic string, qos uint8, retain bool) *WillTopic {
 	p := &WillTopic{
-		Header:    *NewHeader(WILLTOPIC, 0),
+		Header:    *pkts.NewHeader(pkts.WILLTOPIC, 0),
 		QOS:       qos,
 		Retain:    retain,
 		WillTopic: willTopic,
@@ -56,7 +58,7 @@ func (p *WillTopic) decodeFlags(b byte) {
 func (p *WillTopic) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	if p.Header.VarPartLength() > 0 {
 		buf.WriteByte(p.encodeFlags())
 		buf.Write([]byte(p.WillTopic))
@@ -69,7 +71,7 @@ func (p *WillTopic) Write(w io.Writer) error {
 func (p *WillTopic) Unpack(r io.Reader) (err error) {
 	if p.VarPartLength() > 0 {
 		var flagsByte uint8
-		if flagsByte, err = readByte(r); err != nil {
+		if flagsByte, err = pkts.ReadByte(r); err != nil {
 			return
 		}
 		p.decodeFlags(flagsByte)

--- a/packets1/willtopicreq.go
+++ b/packets1/willtopicreq.go
@@ -2,22 +2,24 @@ package packets1
 
 import (
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const willTopicReqVarPartLength uint16 = 0
 
 type WillTopicReq struct {
-	Header
+	pkts.Header
 }
 
 func NewWillTopicReq() *WillTopicReq {
 	return &WillTopicReq{
-		Header: *NewHeader(WILLTOPICREQ, willTopicReqVarPartLength),
+		Header: *pkts.NewHeader(pkts.WILLTOPICREQ, willTopicReqVarPartLength),
 	}
 }
 
 func (p *WillTopicReq) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 
 	_, err := buf.WriteTo(w)
 	return err

--- a/packets1/willtopicresp.go
+++ b/packets1/willtopicresp.go
@@ -3,24 +3,26 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const willTopicRespVarPartLength uint16 = 1
 
 type WillTopicResp struct {
-	Header
+	pkts.Header
 	ReturnCode ReturnCode
 }
 
 func NewWillTopicResp(returnCode ReturnCode) *WillTopicResp {
 	return &WillTopicResp{
-		Header:     *NewHeader(WILLTOPICRESP, willTopicRespVarPartLength),
+		Header:     *pkts.NewHeader(pkts.WILLTOPICRESP, willTopicRespVarPartLength),
 		ReturnCode: returnCode,
 	}
 }
 
 func (p *WillTopicResp) Write(w io.Writer) error {
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(byte(p.ReturnCode))
 
 	_, err := buf.WriteTo(w)
@@ -29,7 +31,7 @@ func (p *WillTopicResp) Write(w io.Writer) error {
 
 func (p *WillTopicResp) Unpack(r io.Reader) (err error) {
 	var returnCodeByte uint8
-	returnCodeByte, err = readByte(r)
+	returnCodeByte, err = pkts.ReadByte(r)
 	p.ReturnCode = ReturnCode(returnCodeByte)
 	return
 }

--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -3,12 +3,14 @@ package packets1
 import (
 	"fmt"
 	"io"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
 const willTopicUpdateHeaderLength uint16 = 1
 
 type WillTopicUpdate struct {
-	Header
+	pkts.Header
 	QOS       uint8
 	Retain    bool
 	WillTopic []byte
@@ -17,7 +19,7 @@ type WillTopicUpdate struct {
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
 func NewWillTopicUpdate(willTopic []byte, qos uint8, retain bool) *WillTopicUpdate {
 	p := &WillTopicUpdate{
-		Header:    *NewHeader(WILLTOPICUPD, 0),
+		Header:    *pkts.NewHeader(pkts.WILLTOPICUPD, 0),
 		QOS:       qos,
 		Retain:    retain,
 		WillTopic: willTopic,
@@ -48,7 +50,7 @@ func (p *WillTopicUpdate) decodeFlags(b byte) {
 func (p *WillTopicUpdate) Write(w io.Writer) error {
 	p.computeLength()
 
-	buf := p.Header.pack()
+	buf := p.Header.Pack()
 	buf.WriteByte(p.encodeFlags())
 	buf.Write(p.WillTopic)
 
@@ -58,7 +60,7 @@ func (p *WillTopicUpdate) Write(w io.Writer) error {
 
 func (p *WillTopicUpdate) Unpack(r io.Reader) (err error) {
 	var flagsByte uint8
-	if flagsByte, err = readByte(r); err != nil {
+	if flagsByte, err = pkts.ReadByte(r); err != nil {
 		return
 	}
 	p.decodeFlags(flagsByte)

--- a/transactions/transaction_store.go
+++ b/transactions/transaction_store.go
@@ -3,25 +3,25 @@ package transactions
 import (
 	"sync"
 
-	pkts1 "github.com/energomonitor/bisquitt/packets1"
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-// TransactionStore stores transactions by MessageID or MessageType
+// TransactionStore stores transactions by MessageID or PacketType
 // (for packets types without MessageID). The typical usage is to store
 // transactions in progress.
 //
 // It's safe for concurrent use.
 type TransactionStore struct {
 	sync.RWMutex
-	byPktID   map[uint16]Transaction
-	byPktType map[pkts1.MessageType]Transaction
+	bypktID   map[uint16]Transaction
+	bypktType map[pkts.PacketType]Transaction
 }
 
 // NewTransactionStore creates a new transaction store.
 func NewTransactionStore() *TransactionStore {
 	return &TransactionStore{
-		byPktID:   make(map[uint16]Transaction),
-		byPktType: make(map[pkts1.MessageType]Transaction),
+		bypktID:   make(map[uint16]Transaction),
+		bypktType: make(map[pkts.PacketType]Transaction),
 	}
 }
 
@@ -29,29 +29,29 @@ func NewTransactionStore() *TransactionStore {
 func (ts *TransactionStore) Store(pktID uint16, transaction Transaction) {
 	ts.Lock()
 	defer ts.Unlock()
-	ts.byPktID[pktID] = transaction
+	ts.bypktID[pktID] = transaction
 }
 
-// StoreByType inserts a new transaction to the store by the MessageType.
-func (ts *TransactionStore) StoreByType(pktType pkts1.MessageType, transaction Transaction) {
+// StoreByType inserts a new transaction to the store by the PacketType.
+func (ts *TransactionStore) StoreByType(pktType pkts.PacketType, transaction Transaction) {
 	ts.Lock()
 	defer ts.Unlock()
-	ts.byPktType[pktType] = transaction
+	ts.bypktType[pktType] = transaction
 }
 
 // Get retrieves a transaction from the store by the MessageID.
 func (ts *TransactionStore) Get(pktID uint16) (Transaction, bool) {
 	ts.RLock()
 	defer ts.RUnlock()
-	transaction, ok := ts.byPktID[pktID]
+	transaction, ok := ts.bypktID[pktID]
 	return transaction, ok
 }
 
-// GetByType retrieves a transaction from the store by the MessageType.
-func (ts *TransactionStore) GetByType(pktType pkts1.MessageType) (Transaction, bool) {
+// GetByType retrieves a transaction from the store by the PacketType.
+func (ts *TransactionStore) GetByType(pktType pkts.PacketType) (Transaction, bool) {
 	ts.Lock()
 	defer ts.Unlock()
-	transaction, ok := ts.byPktType[pktType]
+	transaction, ok := ts.bypktType[pktType]
 	return transaction, ok
 }
 
@@ -59,12 +59,12 @@ func (ts *TransactionStore) GetByType(pktType pkts1.MessageType) (Transaction, b
 func (ts *TransactionStore) Delete(pktID uint16) {
 	ts.Lock()
 	defer ts.Unlock()
-	delete(ts.byPktID, pktID)
+	delete(ts.bypktID, pktID)
 }
 
-// DeleteByType removes a transaction from the store by the MessageType.
-func (ts *TransactionStore) DeleteByType(pktType pkts1.MessageType) {
+// DeleteByType removes a transaction from the store by the PacketType.
+func (ts *TransactionStore) DeleteByType(pktType pkts.PacketType) {
 	ts.Lock()
 	defer ts.Unlock()
-	delete(ts.byPktType, pktType)
+	delete(ts.bypktType, pktType)
 }


### PR DESCRIPTION
This PR is another part of the preparation for MQTT-SN v.2 support. Structures, constants and functions which are common for both versions are moved into the common `packets` package.

MQTT-SN v.2 specification changes some terminology (Message ID -> Packet ID, Topic ID -> Topic Alias). I use the new terminology in the common code, preferring readability of the v.2 code over v.1 code.

Merge after #35