### PR TITLE
Do not use `io.Reader` and `io.Writer` in packets (de)serialization API

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1869,7 +1869,12 @@ func (stp *testSetup) createSocketPair(sockType string, rand *rand.Rand) (*net.U
 }
 
 func (stp *testSetup) send(pkt pkts.Packet) {
-	if err := pkt.Write(stp.conn); err != nil {
+	buf, err := pkt.Pack()
+	if err != nil {
+		stp.t.Fatal(err)
+	}
+	_, err = stp.conn.Write(buf)
+	if err != nil {
 		stp.t.Fatal(err)
 	}
 }

--- a/client/net.go
+++ b/client/net.go
@@ -15,7 +15,15 @@ import (
 
 func (c *Client) send(pkt pkts.Packet) error {
 	c.log.Debug("<- %v", pkt)
-	return pkt.Write(c.conn)
+	buf, err := pkt.Pack()
+	if err != nil {
+		return err
+	}
+	_, err = c.conn.Write(buf)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *Client) keepaliveLoop(ctx context.Context) error {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1321,7 +1321,11 @@ func (stp *testSetup) snSend(pkt snPkts.Packet, setMsgID bool) {
 		}
 	}
 
-	err := pkt.Write(stp.snConn)
+	buf, err := pkt.Pack()
+	if err != nil {
+		stp.t.Fatal(err)
+	}
+	_, err = stp.snConn.Write(buf)
 	if err != nil {
 		stp.t.Fatal(err)
 	}

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -887,7 +887,11 @@ func (h *handler1) snSend(pkt snPkts.Packet) error {
 		return nil
 	}
 	h.log.Debug("<- %v", pkt)
-	err := pkt.Write(h.snConn)
+	buf, err := pkt.Pack()
+	if err != nil {
+		return err
+	}
+	_, err = h.snConn.Write(buf)
 	if err != nil {
 		return err
 	}

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -10,15 +10,7 @@ type Packet interface {
 	fmt.Stringer
 
 	Write(io.Writer) error
-	Unpack(io.Reader) error
-
-	// NOTE: This method is not used anywhere but we must temporary keep it
-	// here because if we remove it, MQTT packets would accidently implement
-	// this interface and we would not be able to type-switch between MQTT
-	// and MQTT-SN packets.
-	// TODO: Remove as soon as this interface is changed and this problem
-	//  disappears.
-	SetVarPartLength(uint16)
+	Unpack([]byte) error
 }
 
 // Packet ID range.

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -3,13 +3,12 @@ package packets
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 )
 
 type Packet interface {
 	fmt.Stringer
 
-	Write(io.Writer) error
+	Pack() ([]byte, error)
 	Unpack([]byte) error
 }
 

--- a/packets1/advertise.go
+++ b/packets1/advertise.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -24,13 +23,13 @@ func NewAdvertise(gatewayID uint8, duration uint16) *Advertise {
 	}
 }
 
-func (p *Advertise) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.WriteByte(p.GatewayID)
-	buf.Write(pkts.EncodeUint16(p.Duration))
+func (p *Advertise) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_ = buf.WriteByte(p.GatewayID)
+	_, _ = buf.Write(pkts.EncodeUint16(p.Duration))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Advertise) Unpack(buf []byte) error {

--- a/packets1/advertise.go
+++ b/packets1/advertise.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -32,13 +33,16 @@ func (p *Advertise) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Advertise) Unpack(r io.Reader) (err error) {
-	if p.GatewayID, err = pkts.ReadByte(r); err != nil {
-		return
+func (p *Advertise) Unpack(buf []byte) error {
+	if len(buf) != int(advertiseVarPartLength) {
+		return fmt.Errorf("bad ADVERTISE packet length: expected %d, got %d",
+			advertiseVarPartLength, len(buf))
 	}
 
-	p.Duration, err = pkts.ReadUint16(r)
-	return
+	p.GatewayID = buf[0]
+	p.Duration = binary.BigEndian.Uint16(buf[1:3])
+
+	return nil
 }
 
 func (p Advertise) String() string {

--- a/packets1/advertise_test.go
+++ b/packets1/advertise_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -22,19 +21,7 @@ func TestAdvertiseStruct(t *testing.T) {
 }
 
 func TestAdvertiseMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewAdvertise(12, 123)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Advertise))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Advertise))
 }

--- a/packets1/auth_test.go
+++ b/packets1/auth_test.go
@@ -1,26 +1,13 @@
 package packets1
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewAuthPlain("test-user", []byte("test-password"))
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Auth))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Auth))
 }

--- a/packets1/connack.go
+++ b/packets1/connack.go
@@ -29,11 +29,15 @@ func (p *Connack) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Connack) Unpack(r io.Reader) (err error) {
-	var returnCodeByte uint8
-	returnCodeByte, err = pkts.ReadByte(r)
-	p.ReturnCode = ReturnCode(returnCodeByte)
-	return
+func (p *Connack) Unpack(buf []byte) error {
+	if len(buf) != int(connackVarPartLength) {
+		return fmt.Errorf("bad CONNACK packet length: expected %d, got %d",
+			connackVarPartLength, len(buf))
+	}
+
+	p.ReturnCode = ReturnCode(buf[0])
+
+	return nil
 }
 
 func (p Connack) String() string {

--- a/packets1/connack.go
+++ b/packets1/connack.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewConnack(returnCode ReturnCode) *Connack {
 	}
 }
 
-func (p *Connack) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.WriteByte(byte(p.ReturnCode))
+func (p *Connack) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_ = buf.WriteByte(byte(p.ReturnCode))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Connack) Unpack(buf []byte) error {

--- a/packets1/connack_test.go
+++ b/packets1/connack_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,19 +18,7 @@ func TestConnackStruct(t *testing.T) {
 }
 
 func TestConnackMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewConnack(RC_CONGESTION)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Connack))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Connack))
 }

--- a/packets1/connect.go
+++ b/packets1/connect.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -54,17 +53,16 @@ func (p *Connect) encodeFlags() byte {
 	return b
 }
 
-func (p *Connect) Write(w io.Writer) error {
+func (p *Connect) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.WriteByte(p.encodeFlags())
-	buf.WriteByte(p.ProtocolID)
-	buf.Write(pkts.EncodeUint16(p.Duration))
-	buf.Write([]byte(p.ClientID))
+	_ = buf.WriteByte(p.encodeFlags())
+	_ = buf.WriteByte(p.ProtocolID)
+	_, _ = buf.Write(pkts.EncodeUint16(p.Duration))
+	_, _ = buf.Write([]byte(p.ClientID))
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *Connect) Unpack(buf []byte) error {

--- a/packets1/connect_test.go
+++ b/packets1/connect_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -26,20 +25,7 @@ func TestConnect(t *testing.T) {
 }
 
 func TestConnectMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewConnect([]byte("test-client"), true, true, 75)
-	err := pkt1.Write(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Connect))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Connect))
 }

--- a/packets1/disconnect.go
+++ b/packets1/disconnect.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -48,13 +49,18 @@ func (p *Disconnect) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Disconnect) Unpack(r io.Reader) (err error) {
-	if p.VarPartLength() == disconnectDurationLength {
-		p.Duration, err = pkts.ReadUint16(r)
-	} else {
+func (p *Disconnect) Unpack(buf []byte) error {
+	switch len(buf) {
+	case int(disconnectDurationLength):
+		p.Duration = binary.BigEndian.Uint16(buf)
+	case 0:
 		p.Duration = 0
+	default:
+		return fmt.Errorf("bad DISCONNECT packet length: expected 0 or 2, got %d",
+			len(buf))
 	}
-	return
+
+	return nil
 }
 
 func (p Disconnect) String() string {

--- a/packets1/disconnect.go
+++ b/packets1/disconnect.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -37,16 +36,15 @@ func (p *Disconnect) computeLength() {
 	}
 }
 
-func (p *Disconnect) Write(w io.Writer) error {
+func (p *Disconnect) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
 	if p.VarPartLength() > 0 {
-		buf.Write(pkts.EncodeUint16(p.Duration))
+		_, _ = buf.Write(pkts.EncodeUint16(p.Duration))
 	}
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *Disconnect) Unpack(buf []byte) error {

--- a/packets1/disconnect_test.go
+++ b/packets1/disconnect_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,20 +18,7 @@ func TestDisconnectStruct(t *testing.T) {
 }
 
 func TestDisconnectMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewDisconnect(75)
-	err := pkt1.Write(buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Disconnect))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Disconnect))
 }

--- a/packets1/gwinfo.go
+++ b/packets1/gwinfo.go
@@ -42,18 +42,16 @@ func (p *GwInfo) Write(w io.Writer) error {
 	return err
 }
 
-func (p *GwInfo) Unpack(r io.Reader) (err error) {
-	if p.GatewayID, err = pkts.ReadByte(r); err != nil {
-		return
+func (p *GwInfo) Unpack(buf []byte) error {
+	if len(buf) < int(gwInfoHeaderLength) {
+		return fmt.Errorf("bad GWINFO packet length: expected >=%d, got %d",
+			gwInfoHeaderLength, len(buf))
 	}
 
-	if p.VarPartLength() > gwInfoHeaderLength {
-		p.GatewayAddress = make([]byte, p.VarPartLength()-gwInfoHeaderLength)
-		_, err = io.ReadFull(r, p.GatewayAddress)
-	} else {
-		p.GatewayAddress = nil
-	}
-	return
+	p.GatewayID = buf[0]
+	p.GatewayAddress = buf[1:]
+
+	return nil
 }
 
 func (p GwInfo) String() string {

--- a/packets1/gwinfo.go
+++ b/packets1/gwinfo.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -31,15 +30,14 @@ func (p *GwInfo) computeLength() {
 	p.Header.SetVarPartLength(gwInfoHeaderLength + addrLength)
 }
 
-func (p *GwInfo) Write(w io.Writer) error {
+func (p *GwInfo) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.WriteByte(p.GatewayID)
-	buf.Write(p.GatewayAddress)
+	_ = buf.WriteByte(p.GatewayID)
+	_, _ = buf.Write(p.GatewayAddress)
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *GwInfo) Unpack(buf []byte) error {

--- a/packets1/gwinfo_test.go
+++ b/packets1/gwinfo_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -21,19 +20,7 @@ func TestGwInfoStruct(t *testing.T) {
 }
 
 func TestGwInfoMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewGwInfo(123, []byte("gateway-address"))
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*GwInfo))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*GwInfo))
 }

--- a/packets1/packets1_test.go
+++ b/packets1/packets1_test.go
@@ -1,0 +1,23 @@
+package packets1
+
+import (
+	"bytes"
+	"testing"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func testPacketMarshal(t *testing.T, pkt1 pkts.Packet) pkts.Packet {
+	buf, err := pkt1.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := bytes.NewReader(buf)
+	pkt2, err := ReadPacket(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pkt2
+}

--- a/packets1/pingreq.go
+++ b/packets1/pingreq.go
@@ -39,14 +39,9 @@ func (p *Pingreq) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Pingreq) Unpack(r io.Reader) (err error) {
-	if p.VarPartLength() > 0 {
-		p.ClientID = make([]byte, p.VarPartLength())
-		_, err = io.ReadFull(r, p.ClientID)
-	} else {
-		p.ClientID = nil
-	}
-	return
+func (p *Pingreq) Unpack(buf []byte) error {
+	p.ClientID = buf
+	return nil
 }
 
 func (p Pingreq) String() string {

--- a/packets1/pingreq.go
+++ b/packets1/pingreq.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -27,16 +26,13 @@ func (p *Pingreq) computeLength() {
 	p.Header.SetVarPartLength(uint16(length))
 }
 
-func (p *Pingreq) Write(w io.Writer) error {
+func (p *Pingreq) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	if len(p.ClientID) > 0 {
-		buf.Write(p.ClientID)
-	}
+	_, _ = buf.Write(p.ClientID)
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *Pingreq) Unpack(buf []byte) error {

--- a/packets1/pingreq_test.go
+++ b/packets1/pingreq_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,19 +18,7 @@ func TestPingreqStruct(t *testing.T) {
 }
 
 func TestPingreqMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPingreq([]byte("test-client"))
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Pingreq))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pingreq))
 }

--- a/packets1/pingresp.go
+++ b/packets1/pingresp.go
@@ -25,7 +25,7 @@ func (p *Pingresp) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Pingresp) Unpack(r io.Reader) error {
+func (p *Pingresp) Unpack(buf []byte) error {
 	return nil
 }
 

--- a/packets1/pingresp.go
+++ b/packets1/pingresp.go
@@ -1,8 +1,6 @@
 package packets1
 
 import (
-	"io"
-
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
@@ -18,11 +16,9 @@ func NewPingresp() *Pingresp {
 	}
 }
 
-func (p *Pingresp) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-
-	_, err := buf.WriteTo(w)
-	return err
+func (p *Pingresp) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+	return buf.Bytes(), nil
 }
 
 func (p *Pingresp) Unpack(buf []byte) error {

--- a/packets1/pingresp_test.go
+++ b/packets1/pingresp_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -18,19 +17,7 @@ func TestPingrespStruct(t *testing.T) {
 }
 
 func TestPingrespMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPingresp()
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Pingresp))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pingresp))
 }

--- a/packets1/puback.go
+++ b/packets1/puback.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -25,14 +24,14 @@ func NewPuback(topicID uint16, returnCode ReturnCode) *Puback {
 	}
 }
 
-func (p *Puback) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.TopicID))
-	buf.Write(pkts.EncodeUint16(p.messageID))
-	buf.WriteByte(byte(p.ReturnCode))
+func (p *Puback) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicID))
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+	_ = buf.WriteByte(byte(p.ReturnCode))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Puback) Unpack(buf []byte) error {

--- a/packets1/puback.go
+++ b/packets1/puback.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -34,19 +35,17 @@ func (p *Puback) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Puback) Unpack(r io.Reader) (err error) {
-	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
-		return
+func (p *Puback) Unpack(buf []byte) error {
+	if len(buf) != int(pubackVarPartLength) {
+		return fmt.Errorf("bad PUBACK packet length: expected %d, got %d",
+			pubackVarPartLength, len(buf))
 	}
 
-	if p.messageID, err = pkts.ReadUint16(r); err != nil {
-		return
-	}
+	p.TopicID = binary.BigEndian.Uint16(buf[0:2])
+	p.messageID = binary.BigEndian.Uint16(buf[2:4])
+	p.ReturnCode = ReturnCode(buf[4])
 
-	var returnCodeByte uint8
-	returnCodeByte, err = pkts.ReadByte(r)
-	p.ReturnCode = ReturnCode(returnCodeByte)
-	return
+	return nil
 }
 
 func (p Puback) String() string {

--- a/packets1/puback_test.go
+++ b/packets1/puback_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 	"testing"
@@ -23,20 +22,8 @@ func TestPubackStruct(t *testing.T) {
 }
 
 func TestPubackMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPuback(123, RC_CONGESTION)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Puback))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Puback))
 }

--- a/packets1/pubcomp.go
+++ b/packets1/pubcomp.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -28,9 +29,15 @@ func (p *Pubcomp) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Pubcomp) Unpack(r io.Reader) (err error) {
-	p.messageID, err = pkts.ReadUint16(r)
-	return
+func (p *Pubcomp) Unpack(buf []byte) error {
+	if len(buf) != int(pubcompVarPartLength) {
+		return fmt.Errorf("bad PUBCOMP packet length: expected %d, got %d",
+			pubcompVarPartLength, len(buf))
+	}
+
+	p.messageID = binary.BigEndian.Uint16(buf)
+
+	return nil
 }
 
 func (p Pubcomp) String() string {

--- a/packets1/pubcomp.go
+++ b/packets1/pubcomp.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewPubcomp() *Pubcomp {
 	}
 }
 
-func (p *Pubcomp) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.messageID))
+func (p *Pubcomp) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Pubcomp) Unpack(buf []byte) error {

--- a/packets1/pubcomp_test.go
+++ b/packets1/pubcomp_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,20 +18,7 @@ func TestPubcompStruct(t *testing.T) {
 }
 
 func TestPubcompMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPubcomp()
-	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Pubcomp))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pubcomp))
 }

--- a/packets1/publish.go
+++ b/packets1/publish.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -62,17 +61,16 @@ func (p *Publish) decodeFlags(b byte) {
 	p.TopicIDType = b & flagsTopicIDTypeBits
 }
 
-func (p *Publish) Write(w io.Writer) error {
+func (p *Publish) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.WriteByte(p.encodeFlags())
-	buf.Write(pkts.EncodeUint16(p.TopicID))
-	buf.Write(pkts.EncodeUint16(p.messageID))
-	buf.Write(p.Data)
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicID))
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+	_, _ = buf.Write(p.Data)
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *Publish) Unpack(buf []byte) error {

--- a/packets1/publish_test.go
+++ b/packets1/publish_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -30,21 +29,9 @@ func TestPublishStruct(t *testing.T) {
 }
 
 func TestPublishMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPublish(123, TIT_PREDEFINED,
 		[]byte("test-payload"), 1, true, true)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Publish))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Publish))
 }

--- a/packets1/pubrec.go
+++ b/packets1/pubrec.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewPubrec() *Pubrec {
 	}
 }
 
-func (p *Pubrec) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.messageID))
+func (p *Pubrec) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Pubrec) Unpack(buf []byte) error {

--- a/packets1/pubrec.go
+++ b/packets1/pubrec.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -28,9 +29,15 @@ func (p *Pubrec) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Pubrec) Unpack(r io.Reader) (err error) {
-	p.messageID, err = pkts.ReadUint16(r)
-	return
+func (p *Pubrec) Unpack(buf []byte) error {
+	if len(buf) != int(pubrecVarPartLength) {
+		return fmt.Errorf("bad PUBREC packet length: expected %d, got %d",
+			pubrecVarPartLength, len(buf))
+	}
+
+	p.messageID = binary.BigEndian.Uint16(buf)
+
+	return nil
 }
 
 func (p Pubrec) String() string {

--- a/packets1/pubrec_test.go
+++ b/packets1/pubrec_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,20 +18,8 @@ func TestPubrecStruct(t *testing.T) {
 }
 
 func TestPubrecMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPubrec()
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Pubrec))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pubrec))
 }

--- a/packets1/pubrel.go
+++ b/packets1/pubrel.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewPubrel() *Pubrel {
 	}
 }
 
-func (p *Pubrel) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.messageID))
+func (p *Pubrel) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Pubrel) Unpack(buf []byte) error {

--- a/packets1/pubrel.go
+++ b/packets1/pubrel.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -28,9 +29,15 @@ func (p *Pubrel) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Pubrel) Unpack(r io.Reader) (err error) {
-	p.messageID, err = pkts.ReadUint16(r)
-	return
+func (p *Pubrel) Unpack(buf []byte) error {
+	if len(buf) != int(pubrelVarPartLength) {
+		return fmt.Errorf("bad PUBREL packet length: expected %d, got %d",
+			pubrelVarPartLength, len(buf))
+	}
+
+	p.messageID = binary.BigEndian.Uint16(buf)
+
+	return nil
 }
 
 func (p Pubrel) String() string {

--- a/packets1/pubrel_test.go
+++ b/packets1/pubrel_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,20 +18,8 @@ func TestPubrelStruct(t *testing.T) {
 }
 
 func TestPubrelMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewPubrel()
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Pubrel))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pubrel))
 }

--- a/packets1/regack.go
+++ b/packets1/regack.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -34,17 +35,17 @@ func (p *Regack) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Regack) Unpack(r io.Reader) (err error) {
-	if p.TopicID, err = pkts.ReadUint16(r); err != nil {
-		return
+func (p *Regack) Unpack(buf []byte) error {
+	if len(buf) != int(regackVarPartLength) {
+		return fmt.Errorf("bad REGACK packet length: expected %d, got %d",
+			regackVarPartLength, len(buf))
 	}
-	if p.messageID, err = pkts.ReadUint16(r); err != nil {
-		return
-	}
-	var returnCodeByte uint8
-	returnCodeByte, err = pkts.ReadByte(r)
-	p.ReturnCode = ReturnCode(returnCodeByte)
-	return
+
+	p.TopicID = binary.BigEndian.Uint16(buf[0:2])
+	p.messageID = binary.BigEndian.Uint16(buf[2:4])
+	p.ReturnCode = ReturnCode(buf[4])
+
+	return nil
 }
 
 func (p Regack) String() string {

--- a/packets1/regack.go
+++ b/packets1/regack.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -25,14 +24,14 @@ func NewRegack(topicID uint16, returnCode ReturnCode) *Regack {
 	}
 }
 
-func (p *Regack) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.TopicID))
-	buf.Write(pkts.EncodeUint16(p.messageID))
-	buf.WriteByte(byte(p.ReturnCode))
+func (p *Regack) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicID))
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+	_ = buf.WriteByte(byte(p.ReturnCode))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Regack) Unpack(buf []byte) error {

--- a/packets1/regack_test.go
+++ b/packets1/regack_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -23,20 +22,8 @@ func TestRegackStruct(t *testing.T) {
 }
 
 func TestRegackMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewRegack(123, RC_CONGESTION)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Regack))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Regack))
 }

--- a/packets1/register.go
+++ b/packets1/register.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -33,16 +32,15 @@ func (p *Register) computeLength() {
 	p.Header.SetVarPartLength(registerHeaderLength + topicLength)
 }
 
-func (p *Register) Write(w io.Writer) error {
+func (p *Register) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.TopicID))
-	buf.Write(pkts.EncodeUint16(p.messageID))
-	buf.Write([]byte(p.TopicName))
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicID))
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+	_, _ = buf.Write([]byte(p.TopicName))
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *Register) Unpack(buf []byte) error {

--- a/packets1/register_test.go
+++ b/packets1/register_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -22,20 +21,8 @@ func TestRegisterStruct(t *testing.T) {
 }
 
 func TestRegisterMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewRegister(123, "test-topic")
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Register))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Register))
 }

--- a/packets1/searchgw.go
+++ b/packets1/searchgw.go
@@ -29,9 +29,15 @@ func (p *SearchGw) Write(w io.Writer) error {
 	return err
 }
 
-func (p *SearchGw) Unpack(r io.Reader) (err error) {
-	p.Radius, err = pkts.ReadByte(r)
-	return
+func (p *SearchGw) Unpack(buf []byte) error {
+	if len(buf) != int(searchGwVarPartLength) {
+		return fmt.Errorf("bad SEARCHGW packet length: expected %d, got %d",
+			searchGwVarPartLength, len(buf))
+	}
+
+	p.Radius = buf[0]
+
+	return nil
 }
 
 func (p SearchGw) String() string {

--- a/packets1/searchgw.go
+++ b/packets1/searchgw.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewSearchGw(radius uint8) *SearchGw {
 	}
 }
 
-func (p *SearchGw) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.WriteByte(p.Radius)
+func (p *SearchGw) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_ = buf.WriteByte(p.Radius)
+
+	return buf.Bytes(), nil
 }
 
 func (p *SearchGw) Unpack(buf []byte) error {

--- a/packets1/searchgw_test.go
+++ b/packets1/searchgw_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -20,19 +19,7 @@ func TestSearchGwStruct(t *testing.T) {
 }
 
 func TestSearchGwMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewSearchGw(123)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*SearchGw))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*SearchGw))
 }

--- a/packets1/suback.go
+++ b/packets1/suback.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -37,15 +36,15 @@ func (p *Suback) decodeFlags(b byte) {
 	p.QOS = (b & flagsQOSBits) >> 5
 }
 
-func (p *Suback) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.WriteByte(p.encodeFlags())
-	buf.Write(pkts.EncodeUint16(p.TopicID))
-	buf.Write(pkts.EncodeUint16(p.messageID))
-	buf.WriteByte(byte(p.ReturnCode))
+func (p *Suback) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicID))
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+	_ = buf.WriteByte(byte(p.ReturnCode))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Suback) Unpack(buf []byte) error {

--- a/packets1/suback_test.go
+++ b/packets1/suback_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -25,20 +24,8 @@ func TestSubackStruct(t *testing.T) {
 }
 
 func TestSubackMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewSuback(123, 1, RC_CONGESTION)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Suback))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Suback))
 }

--- a/packets1/subscribe_test.go
+++ b/packets1/subscribe_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -28,39 +27,15 @@ func TestSubscribeStruct(t *testing.T) {
 }
 
 func TestSubscribeMarshalString(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewSubscribe(0, TIT_STRING, []byte("test-topic"), 1, true)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Subscribe))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Subscribe))
 }
 
 func TestSubscribeMarshalShort(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewSubscribe(123, TIT_SHORT, nil, 1, true)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Subscribe))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Subscribe))
 }

--- a/packets1/unsuback.go
+++ b/packets1/unsuback.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -28,9 +29,15 @@ func (p *Unsuback) Write(w io.Writer) error {
 	return err
 }
 
-func (p *Unsuback) Unpack(r io.Reader) (err error) {
-	p.messageID, err = pkts.ReadUint16(r)
-	return
+func (p *Unsuback) Unpack(buf []byte) error {
+	if len(buf) != int(unsubackVarPartLength) {
+		return fmt.Errorf("bad UNSUBACK packet length: expected %d, got %d",
+			unsubackVarPartLength, len(buf))
+	}
+
+	p.messageID = binary.BigEndian.Uint16(buf)
+
+	return nil
 }
 
 func (p Unsuback) String() string {

--- a/packets1/unsuback.go
+++ b/packets1/unsuback.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewUnsuback() *Unsuback {
 	}
 }
 
-func (p *Unsuback) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.Write(pkts.EncodeUint16(p.messageID))
+func (p *Unsuback) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
+
+	return buf.Bytes(), nil
 }
 
 func (p *Unsuback) Unpack(buf []byte) error {

--- a/packets1/unsuback_test.go
+++ b/packets1/unsuback_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,20 +18,8 @@ func TestUnsubackStruct(t *testing.T) {
 }
 
 func TestUnsubackMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewUnsuback()
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Unsuback))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsuback))
 }

--- a/packets1/unsubscribe.go
+++ b/packets1/unsubscribe.go
@@ -3,7 +3,6 @@ package packets1
 import (
 	"encoding/binary"
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -51,21 +50,20 @@ func (p *Unsubscribe) decodeFlags(b byte) {
 	p.TopicIDType = b & flagsTopicIDTypeBits
 }
 
-func (p *Unsubscribe) Write(w io.Writer) error {
+func (p *Unsubscribe) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.WriteByte(p.encodeFlags())
-	buf.Write(pkts.EncodeUint16(p.messageID))
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.messageID))
 	switch p.TopicIDType {
 	case TIT_STRING:
-		buf.Write(p.TopicName)
+		_, _ = buf.Write(p.TopicName)
 	case TIT_PREDEFINED, TIT_SHORT:
-		buf.Write(pkts.EncodeUint16(p.TopicID))
+		_, _ = buf.Write(pkts.EncodeUint16(p.TopicID))
 	}
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *Unsubscribe) Unpack(buf []byte) error {

--- a/packets1/unsubscribe_test.go
+++ b/packets1/unsubscribe_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -24,39 +23,15 @@ func TestUnsubscribeStruct(t *testing.T) {
 }
 
 func TestUnsubscribeMarshalString(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewUnsubscribe(0, TIT_STRING, []byte("test-topic"))
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Unsubscribe))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
 }
 
 func TestUnsubscribeMarshalShort(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewUnsubscribe(123, TIT_SHORT, nil)
 	pkt1.SetMessageID(12)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*Unsubscribe))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
 }

--- a/packets1/willmsg.go
+++ b/packets1/willmsg.go
@@ -37,10 +37,9 @@ func (p *WillMsg) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillMsg) Unpack(r io.Reader) (err error) {
-	p.WillMsg = make([]byte, p.VarPartLength())
-	_, err = io.ReadFull(r, p.WillMsg)
-	return
+func (p *WillMsg) Unpack(buf []byte) error {
+	p.WillMsg = buf
+	return nil
 }
 
 func (p WillMsg) String() string {

--- a/packets1/willmsg.go
+++ b/packets1/willmsg.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -27,14 +26,13 @@ func (p *WillMsg) computeLength() {
 	p.Header.SetVarPartLength(uint16(msgLength))
 }
 
-func (p *WillMsg) Write(w io.Writer) error {
+func (p *WillMsg) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.Write(p.WillMsg)
+	_, _ = buf.Write(p.WillMsg)
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *WillMsg) Unpack(buf []byte) error {

--- a/packets1/willmsg_test.go
+++ b/packets1/willmsg_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,19 +18,7 @@ func TestWillMsgStruct(t *testing.T) {
 }
 
 func TestWillMsgMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillMsg([]byte("test-message"))
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillMsg))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillMsg))
 }

--- a/packets1/willmsgreq.go
+++ b/packets1/willmsgreq.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -19,11 +18,9 @@ func NewWillMsgReq() *WillMsgReq {
 	}
 }
 
-func (p *WillMsgReq) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-
-	_, err := buf.WriteTo(w)
-	return err
+func (p *WillMsgReq) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+	return buf.Bytes(), nil
 }
 
 func (p *WillMsgReq) Unpack(buf []byte) error {

--- a/packets1/willmsgreq.go
+++ b/packets1/willmsgreq.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"fmt"
 	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
@@ -25,7 +26,12 @@ func (p *WillMsgReq) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillMsgReq) Unpack(r io.Reader) error {
+func (p *WillMsgReq) Unpack(buf []byte) error {
+	if len(buf) <= int(willMsgReqVarPartLength) {
+		return fmt.Errorf("bad WILLMSGREQ packet length: expected %d, got %d",
+			willMsgReqVarPartLength, len(buf))
+	}
+
 	return nil
 }
 

--- a/packets1/willmsgreq_test.go
+++ b/packets1/willmsgreq_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -17,19 +16,7 @@ func TestWillMsgReqStruct(t *testing.T) {
 }
 
 func TestWillMsgReqMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillMsgReq()
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillMsgReq))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillMsgReq))
 }

--- a/packets1/willmsgresp.go
+++ b/packets1/willmsgresp.go
@@ -29,11 +29,15 @@ func (p *WillMsgResp) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillMsgResp) Unpack(r io.Reader) (err error) {
-	var returnCodeByte uint8
-	returnCodeByte, err = pkts.ReadByte(r)
-	p.ReturnCode = ReturnCode(returnCodeByte)
-	return
+func (p *WillMsgResp) Unpack(buf []byte) error {
+	if len(buf) != int(willMsgRespVarPartLength) {
+		return fmt.Errorf("bad WILLMSGRESP packet length: expected %d, got %d",
+			willMsgRespVarPartLength, len(buf))
+	}
+
+	p.ReturnCode = ReturnCode(buf[0])
+
+	return nil
 }
 
 func (p WillMsgResp) String() string {

--- a/packets1/willmsgresp.go
+++ b/packets1/willmsgresp.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewWillMsgResp(returnCode ReturnCode) *WillMsgResp {
 	}
 }
 
-func (p *WillMsgResp) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.WriteByte(byte(p.ReturnCode))
+func (p *WillMsgResp) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_ = buf.WriteByte(byte(p.ReturnCode))
+
+	return buf.Bytes(), nil
 }
 
 func (p *WillMsgResp) Unpack(buf []byte) error {

--- a/packets1/willmsgresp_test.go
+++ b/packets1/willmsgresp_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -18,19 +17,7 @@ func TestWillMsgRespStruct(t *testing.T) {
 }
 
 func TestWillMsgRespMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillMsgResp(RC_CONGESTION)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillMsgResp))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillMsgResp))
 }

--- a/packets1/willmsgupd.go
+++ b/packets1/willmsgupd.go
@@ -37,10 +37,9 @@ func (p *WillMsgUpdate) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillMsgUpdate) Unpack(r io.Reader) (err error) {
-	p.WillMsg = make([]byte, p.VarPartLength())
-	_, err = io.ReadFull(r, p.WillMsg)
-	return
+func (p *WillMsgUpdate) Unpack(buf []byte) error {
+	p.WillMsg = buf
+	return nil
 }
 
 func (p WillMsgUpdate) String() string {

--- a/packets1/willmsgupd.go
+++ b/packets1/willmsgupd.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -27,14 +26,13 @@ func (p *WillMsgUpdate) computeLength() {
 	p.Header.SetVarPartLength(uint16(length))
 }
 
-func (p *WillMsgUpdate) Write(w io.Writer) error {
+func (p *WillMsgUpdate) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.Write(p.WillMsg)
+	_, _ = buf.Write(p.WillMsg)
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *WillMsgUpdate) Unpack(buf []byte) error {

--- a/packets1/willmsgupd_test.go
+++ b/packets1/willmsgupd_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -19,19 +18,7 @@ func TestWillMsgUpdateStruct(t *testing.T) {
 }
 
 func TestWillMsgUpdateMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillMsgUpdate([]byte("test-message"))
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillMsgUpdate))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillMsgUpdate))
 }

--- a/packets1/willtopic.go
+++ b/packets1/willtopic.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -55,17 +54,16 @@ func (p *WillTopic) decodeFlags(b byte) {
 	p.Retain = (b & flagsRetainBit) == flagsRetainBit
 }
 
-func (p *WillTopic) Write(w io.Writer) error {
+func (p *WillTopic) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
 	if p.Header.VarPartLength() > 0 {
-		buf.WriteByte(p.encodeFlags())
-		buf.Write([]byte(p.WillTopic))
+		_ = buf.WriteByte(p.encodeFlags())
+		_, _ = buf.Write([]byte(p.WillTopic))
 	}
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *WillTopic) Unpack(buf []byte) error {

--- a/packets1/willtopic_test.go
+++ b/packets1/willtopic_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -23,19 +22,7 @@ func TestWillTopicStruct(t *testing.T) {
 }
 
 func TestWillTopicMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillTopic("test-topic", 1, true)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillTopic))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillTopic))
 }

--- a/packets1/willtopicreq.go
+++ b/packets1/willtopicreq.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -19,11 +18,9 @@ func NewWillTopicReq() *WillTopicReq {
 	}
 }
 
-func (p *WillTopicReq) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-
-	_, err := buf.WriteTo(w)
-	return err
+func (p *WillTopicReq) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+	return buf.Bytes(), nil
 }
 
 func (p *WillTopicReq) Unpack(buf []byte) error {

--- a/packets1/willtopicreq.go
+++ b/packets1/willtopicreq.go
@@ -1,6 +1,7 @@
 package packets1
 
 import (
+	"fmt"
 	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
@@ -25,7 +26,11 @@ func (p *WillTopicReq) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillTopicReq) Unpack(r io.Reader) error {
+func (p *WillTopicReq) Unpack(buf []byte) error {
+	if len(buf) != int(willTopicReqVarPartLength) {
+		return fmt.Errorf("bad WILLTOPICREQ packet length: Expected %d, got %d",
+			willTopicReqVarPartLength, len(buf))
+	}
 	return nil
 }
 

--- a/packets1/willtopicreq_test.go
+++ b/packets1/willtopicreq_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -17,19 +16,7 @@ func TestWillTopicReqStruct(t *testing.T) {
 }
 
 func TestWillTopicReqMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillTopicReq()
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillTopicReq))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillTopicReq))
 }

--- a/packets1/willtopicresp.go
+++ b/packets1/willtopicresp.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -21,12 +20,12 @@ func NewWillTopicResp(returnCode ReturnCode) *WillTopicResp {
 	}
 }
 
-func (p *WillTopicResp) Write(w io.Writer) error {
-	buf := p.Header.Pack()
-	buf.WriteByte(byte(p.ReturnCode))
+func (p *WillTopicResp) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
 
-	_, err := buf.WriteTo(w)
-	return err
+	_ = buf.WriteByte(byte(p.ReturnCode))
+
+	return buf.Bytes(), nil
 }
 
 func (p *WillTopicResp) Unpack(buf []byte) error {

--- a/packets1/willtopicresp.go
+++ b/packets1/willtopicresp.go
@@ -29,11 +29,15 @@ func (p *WillTopicResp) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillTopicResp) Unpack(r io.Reader) (err error) {
-	var returnCodeByte uint8
-	returnCodeByte, err = pkts.ReadByte(r)
-	p.ReturnCode = ReturnCode(returnCodeByte)
-	return
+func (p *WillTopicResp) Unpack(buf []byte) error {
+	if len(buf) != int(willTopicRespVarPartLength) {
+		return fmt.Errorf("bad WILLTOPICRESP packet length: expected %d, got %d",
+			willTopicRespVarPartLength, len(buf))
+	}
+
+	p.ReturnCode = ReturnCode(buf[0])
+
+	return nil
 }
 
 func (p WillTopicResp) String() string {

--- a/packets1/willtopicresp_test.go
+++ b/packets1/willtopicresp_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -18,19 +17,7 @@ func TestWillTopicRespStruct(t *testing.T) {
 }
 
 func TestWillTopicRespMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillTopicResp(RC_CONGESTION)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillTopicResp))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillTopicResp))
 }

--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -58,16 +58,16 @@ func (p *WillTopicUpdate) Write(w io.Writer) error {
 	return err
 }
 
-func (p *WillTopicUpdate) Unpack(r io.Reader) (err error) {
-	var flagsByte uint8
-	if flagsByte, err = pkts.ReadByte(r); err != nil {
-		return
+func (p *WillTopicUpdate) Unpack(buf []byte) error {
+	if len(buf) <= int(willTopicUpdateHeaderLength) {
+		return fmt.Errorf("bad WILLTOPICUPDATE packet length: expected >%d, got %d",
+			willTopicUpdateHeaderLength, len(buf))
 	}
-	p.decodeFlags(flagsByte)
 
-	p.WillTopic = make([]byte, p.VarPartLength()-willTopicUpdateHeaderLength)
-	_, err = io.ReadFull(r, p.WillTopic)
-	return
+	p.decodeFlags(buf[0])
+	p.WillTopic = buf[1:]
+
+	return nil
 }
 
 func (p WillTopicUpdate) String() string {

--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -2,7 +2,6 @@ package packets1
 
 import (
 	"fmt"
-	"io"
 
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
@@ -47,15 +46,14 @@ func (p *WillTopicUpdate) decodeFlags(b byte) {
 	p.Retain = (b & flagsRetainBit) == flagsRetainBit
 }
 
-func (p *WillTopicUpdate) Write(w io.Writer) error {
+func (p *WillTopicUpdate) Pack() ([]byte, error) {
 	p.computeLength()
+	buf := p.Header.PackToBuffer()
 
-	buf := p.Header.Pack()
-	buf.WriteByte(p.encodeFlags())
-	buf.Write(p.WillTopic)
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(p.WillTopic)
 
-	_, err := buf.WriteTo(w)
-	return err
+	return buf.Bytes(), nil
 }
 
 func (p *WillTopicUpdate) Unpack(buf []byte) error {

--- a/packets1/willtopicupd_test.go
+++ b/packets1/willtopicupd_test.go
@@ -1,7 +1,6 @@
 package packets1
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -24,19 +23,7 @@ func TestWillTopicUpdateStruct(t *testing.T) {
 }
 
 func TestWillTopicUpdateMarshal(t *testing.T) {
-	assert := assert.New(t)
-	buf := bytes.NewBuffer(nil)
-
 	pkt1 := NewWillTopicUpdate([]byte("test-topic"), 1, true)
-	if err := pkt1.Write(buf); err != nil {
-		t.Fatal(err)
-	}
-
-	r := bytes.NewReader(buf.Bytes())
-	pkt2, err := ReadPacket(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(pkt1, pkt2.(*WillTopicUpdate))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillTopicUpdate))
 }


### PR DESCRIPTION
Go's `io.Reader` and `io.Writer` interfaces are semantically overloaded IMHO. There are many possible behaviors of the `Read()` function according to EOF and stream/packet sources. Implementing all possible scenarios correctly would be complicated and error prone.

On the other way, our packets (de)serialization works strictly on byte buffers and is well-defined. So there is IMHO no reason to use `Reader`/`Writer`. If any client code really needs `Reader`/`Writer`, it can use e.g. `bytes.Buffer` as a wrapper...

Merge after #36