### PR TITLE
Rename `Will{Msg,Topic}Update` to `Will{Msg,Topic}Upd`

### DIFF
--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -147,7 +147,7 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet) {
 	case pkts.WILLTOPICRESP:
 		pkt = &WillTopicResp{Header: h}
 	case pkts.WILLMSGUPD:
-		pkt = &WillMsgUpdate{Header: h}
+		pkt = &WillMsgUpd{Header: h}
 	case pkts.WILLMSGRESP:
 		pkt = &WillMsgResp{Header: h}
 	}

--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -143,7 +143,7 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet) {
 	case pkts.DISCONNECT:
 		pkt = &Disconnect{Header: h}
 	case pkts.WILLTOPICUPD:
-		pkt = &WillTopicUpdate{Header: h}
+		pkt = &WillTopicUpd{Header: h}
 	case pkts.WILLTOPICRESP:
 		pkt = &WillTopicResp{Header: h}
 	case pkts.WILLMSGUPD:

--- a/packets1/willmsgupd.go
+++ b/packets1/willmsgupd.go
@@ -6,14 +6,14 @@ import (
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-type WillMsgUpdate struct {
+type WillMsgUpd struct {
 	pkts.Header
 	WillMsg []byte
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewWillMsgUpdate(willMsg []byte) *WillMsgUpdate {
-	p := &WillMsgUpdate{
+func NewWillMsgUpd(willMsg []byte) *WillMsgUpd {
+	p := &WillMsgUpd{
 		Header:  *pkts.NewHeader(pkts.WILLMSGUPD, 0),
 		WillMsg: willMsg,
 	}
@@ -21,12 +21,12 @@ func NewWillMsgUpdate(willMsg []byte) *WillMsgUpdate {
 	return p
 }
 
-func (p *WillMsgUpdate) computeLength() {
+func (p *WillMsgUpd) computeLength() {
 	length := len(p.WillMsg)
 	p.Header.SetVarPartLength(uint16(length))
 }
 
-func (p *WillMsgUpdate) Pack() ([]byte, error) {
+func (p *WillMsgUpd) Pack() ([]byte, error) {
 	p.computeLength()
 	buf := p.Header.PackToBuffer()
 
@@ -35,11 +35,11 @@ func (p *WillMsgUpdate) Pack() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (p *WillMsgUpdate) Unpack(buf []byte) error {
+func (p *WillMsgUpd) Unpack(buf []byte) error {
 	p.WillMsg = buf
 	return nil
 }
 
-func (p WillMsgUpdate) String() string {
-	return fmt.Sprintf("WILLMSGUPDATE(WillMsg=%#v)", string(p.WillMsg))
+func (p WillMsgUpd) String() string {
+	return fmt.Sprintf("WILLMSGUPD(WillMsg=%#v)", string(p.WillMsg))
 }

--- a/packets1/willmsgupd_test.go
+++ b/packets1/willmsgupd_test.go
@@ -7,18 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWillMsgUpdateStruct(t *testing.T) {
+func TestWillMsgUpdStruct(t *testing.T) {
 	willMsg := []byte("test-msg")
-	pkt := NewWillMsgUpdate(willMsg)
+	pkt := NewWillMsgUpd(willMsg)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillMsgUpdate", reflect.TypeOf(pkt).String(), "Type should be WillMsgUpdate")
+		assert.Equal(t, "*packets1.WillMsgUpd", reflect.TypeOf(pkt).String(), "Type should be WillMsgUpd")
 		assert.Equal(t, willMsg, pkt.WillMsg, "Bad WillMsg value")
 	}
 }
 
-func TestWillMsgUpdateMarshal(t *testing.T) {
-	pkt1 := NewWillMsgUpdate([]byte("test-message"))
+func TestWillMsgUpdMarshal(t *testing.T) {
+	pkt1 := NewWillMsgUpd([]byte("test-message"))
 	pkt2 := testPacketMarshal(t, pkt1)
-	assert.Equal(t, pkt1, pkt2.(*WillMsgUpdate))
+	assert.Equal(t, pkt1, pkt2.(*WillMsgUpd))
 }

--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -6,9 +6,9 @@ import (
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-const willTopicUpdateHeaderLength uint16 = 1
+const willTopicUpdHeaderLength uint16 = 1
 
-type WillTopicUpdate struct {
+type WillTopicUpd struct {
 	pkts.Header
 	QOS       uint8
 	Retain    bool
@@ -16,8 +16,8 @@ type WillTopicUpdate struct {
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewWillTopicUpdate(willTopic []byte, qos uint8, retain bool) *WillTopicUpdate {
-	p := &WillTopicUpdate{
+func NewWillTopicUpd(willTopic []byte, qos uint8, retain bool) *WillTopicUpd {
+	p := &WillTopicUpd{
 		Header:    *pkts.NewHeader(pkts.WILLTOPICUPD, 0),
 		QOS:       qos,
 		Retain:    retain,
@@ -27,12 +27,12 @@ func NewWillTopicUpdate(willTopic []byte, qos uint8, retain bool) *WillTopicUpda
 	return p
 }
 
-func (p *WillTopicUpdate) computeLength() {
+func (p *WillTopicUpd) computeLength() {
 	topicLength := uint16(len(p.WillTopic))
-	p.Header.SetVarPartLength(willTopicUpdateHeaderLength + topicLength)
+	p.Header.SetVarPartLength(willTopicUpdHeaderLength + topicLength)
 }
 
-func (p *WillTopicUpdate) encodeFlags() byte {
+func (p *WillTopicUpd) encodeFlags() byte {
 	var b byte
 	b |= (p.QOS << 5) & flagsQOSBits
 	if p.Retain {
@@ -41,12 +41,12 @@ func (p *WillTopicUpdate) encodeFlags() byte {
 	return b
 }
 
-func (p *WillTopicUpdate) decodeFlags(b byte) {
+func (p *WillTopicUpd) decodeFlags(b byte) {
 	p.QOS = (b & flagsQOSBits) >> 5
 	p.Retain = (b & flagsRetainBit) == flagsRetainBit
 }
 
-func (p *WillTopicUpdate) Pack() ([]byte, error) {
+func (p *WillTopicUpd) Pack() ([]byte, error) {
 	p.computeLength()
 	buf := p.Header.PackToBuffer()
 
@@ -56,10 +56,10 @@ func (p *WillTopicUpdate) Pack() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (p *WillTopicUpdate) Unpack(buf []byte) error {
-	if len(buf) <= int(willTopicUpdateHeaderLength) {
-		return fmt.Errorf("bad WILLTOPICUPDATE packet length: expected >%d, got %d",
-			willTopicUpdateHeaderLength, len(buf))
+func (p *WillTopicUpd) Unpack(buf []byte) error {
+	if len(buf) <= int(willTopicUpdHeaderLength) {
+		return fmt.Errorf("bad WILLTOPICUPD packet length: expected >%d, got %d",
+			willTopicUpdHeaderLength, len(buf))
 	}
 
 	p.decodeFlags(buf[0])
@@ -68,7 +68,7 @@ func (p *WillTopicUpdate) Unpack(buf []byte) error {
 	return nil
 }
 
-func (p WillTopicUpdate) String() string {
-	return fmt.Sprintf("WILLTOPICUPDATE(WillTopic=%#v, QOS=%d, Retain=%t)",
+func (p WillTopicUpd) String() string {
+	return fmt.Sprintf("WILLTOPICUPD(WillTopic=%#v, QOS=%d, Retain=%t)",
 		p.WillTopic, p.QOS, p.Retain)
 }

--- a/packets1/willtopicupd_test.go
+++ b/packets1/willtopicupd_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWillTopicUpdateStruct(t *testing.T) {
+func TestWillTopicUpdStruct(t *testing.T) {
 	willTopic := []byte("test-topic")
 	qos := uint8(1)
 	retain := true
-	pkt := NewWillTopicUpdate(willTopic, qos, retain)
+	pkt := NewWillTopicUpd(willTopic, qos, retain)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillTopicUpdate", reflect.TypeOf(pkt).String(), "Type should be WillTopicUpdate")
+		assert.Equal(t, "*packets1.WillTopicUpd", reflect.TypeOf(pkt).String(), "Type should be WillTopicUpd")
 		assert.Equal(t, qos, pkt.QOS, "Bad QOS value")
 		assert.Equal(t, retain, pkt.Retain, "Bad Retain flag value")
 		assert.Equal(t, willTopic, pkt.WillTopic, "Bad WillTopic value")
@@ -22,8 +22,8 @@ func TestWillTopicUpdateStruct(t *testing.T) {
 
 }
 
-func TestWillTopicUpdateMarshal(t *testing.T) {
-	pkt1 := NewWillTopicUpdate([]byte("test-topic"), 1, true)
+func TestWillTopicUpdMarshal(t *testing.T) {
+	pkt1 := NewWillTopicUpd([]byte("test-topic"), 1, true)
 	pkt2 := testPacketMarshal(t, pkt1)
-	assert.Equal(t, pkt1, pkt2.(*WillTopicUpdate))
+	assert.Equal(t, pkt1, pkt2.(*WillTopicUpd))
 }


### PR DESCRIPTION
The name of the packets are `WILLMSGUPD` and `WILLTOPICUPD` and the corresponding structs should be named the same.