### PR TITLE
Make `Topic` type `string`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -362,7 +362,7 @@ func (c *Client) Register(topic string) error {
 func (c *Client) subscribe(topicName string, topicIDType uint8, topicID uint16, qos uint8, callback MessageHandlerFunc) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newSubscribeTransaction(c, msgID, callback)
-	subscribe := pkts1.NewSubscribe(topicID, topicIDType, []byte(topicName), qos, false)
+	subscribe := pkts1.NewSubscribe(topicID, topicIDType, topicName, qos, false)
 	subscribe.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, subscribe)
@@ -397,7 +397,7 @@ func (c *Client) SubscribePredefined(topicID uint16, qos uint8, callback Message
 func (c *Client) unsubscribe(topicName string, topicIDType uint8, topicID uint16) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newUnsubscribeTransaction(c, msgID)
-	unsubscribe := pkts1.NewUnsubscribe(topicID, topicIDType, []byte(topicName))
+	unsubscribe := pkts1.NewUnsubscribe(topicID, topicIDType, topicName)
 	unsubscribe.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, unsubscribe)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -929,7 +929,7 @@ func TestSubscribeQOS0(t *testing.T) {
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
 		subscribe.QOS = qos
-		assert.Equal([]byte(topic), subscribe.TopicName)
+		assert.Equal(topic, subscribe.TopicName)
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
@@ -997,7 +997,7 @@ func TestSubscribeQOS1(t *testing.T) {
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
 		subscribe.QOS = qos
-		assert.Equal([]byte(topic), subscribe.TopicName)
+		assert.Equal(topic, subscribe.TopicName)
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
@@ -1069,7 +1069,7 @@ func TestSubscribeQOS2(t *testing.T) {
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
 		subscribe.QOS = qos
-		assert.Equal([]byte(topic), subscribe.TopicName)
+		assert.Equal(topic, subscribe.TopicName)
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
@@ -1155,7 +1155,7 @@ func TestSubscribeWildcard(t *testing.T) {
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
-		assert.Equal([]byte(wildcard), subscribe.TopicName)
+		assert.Equal(wildcard, subscribe.TopicName)
 
 		// client <--SUBACK-- GW
 		suback := pkts1.NewSuback(0, 0, pkts1.RC_ACCEPTED)
@@ -1374,7 +1374,7 @@ func TestUnsubscribeString(t *testing.T) {
 		// client --SUBSCRIBE--> GW
 		subscribe := stp.recv().(*pkts1.Subscribe)
 		subscribe.QOS = qos
-		assert.Equal([]byte(topic), subscribe.TopicName)
+		assert.Equal(topic, subscribe.TopicName)
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
@@ -1384,7 +1384,7 @@ func TestUnsubscribeString(t *testing.T) {
 
 		// client --UNSUBSCRIBE--> GW
 		unsubscribe := stp.recv().(*pkts1.Unsubscribe)
-		assert.Equal([]byte(topic), unsubscribe.TopicName)
+		assert.Equal(topic, unsubscribe.TopicName)
 		assert.Equal(pkts1.TIT_STRING, unsubscribe.TopicIDType)
 
 		// client <--UNSUBACK-- GW

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -130,7 +130,7 @@ func TestPubSubPredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, nil, 0, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -201,7 +201,7 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, nil, 0, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -279,7 +279,7 @@ func TestDisconnectedSubscribe(t *testing.T) {
 
 	stp.snSend(
 		snPkts1.NewSubscribe(0, snPkts1.TIT_STRING,
-			[]byte("test-topic-0"), 0, false),
+			"test-topic-0", 0, false),
 		true,
 	)
 
@@ -897,7 +897,7 @@ func TestUnsubscribeString(t *testing.T) {
 	stp.subscribe(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(0, snPkts1.TIT_STRING, []byte(topic))
+	snUnsubscribe := snPkts1.NewUnsubscribe(0, snPkts1.TIT_STRING, topic)
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -931,7 +931,7 @@ func TestUnsubscribeShort(t *testing.T) {
 	stp.subscribeShort(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(snPkts.EncodeShortTopic(topic), snPkts1.TIT_SHORT, []byte(""))
+	snUnsubscribe := snPkts1.NewUnsubscribe(snPkts.EncodeShortTopic(topic), snPkts1.TIT_SHORT, "")
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -972,7 +972,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, nil, 0, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -994,7 +994,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(topicID, snPkts1.TIT_PREDEFINED, []byte(""))
+	snUnsubscribe := snPkts1.NewUnsubscribe(topicID, snPkts1.TIT_PREDEFINED, "")
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -1505,7 +1505,7 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	assert := assert.New(stp.t)
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts1.NewSubscribe(0, snPkts1.TIT_STRING, []byte(topic), qos, false)
+	snSubscribe := snPkts1.NewSubscribe(0, snPkts1.TIT_STRING, topic, qos, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -1542,7 +1542,7 @@ func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 
 	// client --SUBSCRIBE--> GW
 	topicID := snPkts.EncodeShortTopic(topic)
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_SHORT, nil, qos, false)
+	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_SHORT, "", qos, false)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker

--- a/packets1/subscribe_test.go
+++ b/packets1/subscribe_test.go
@@ -10,7 +10,7 @@ import (
 func TestSubscribeStruct(t *testing.T) {
 	topicID := uint16(12)
 	topicIDType := TIT_REGISTERED
-	topicName := []byte("test-topic")
+	topicName := "test-topic"
 	qos := uint8(1)
 	dup := true
 	pkt := NewSubscribe(topicID, topicIDType, topicName, qos, dup)
@@ -27,14 +27,14 @@ func TestSubscribeStruct(t *testing.T) {
 }
 
 func TestSubscribeMarshalString(t *testing.T) {
-	pkt1 := NewSubscribe(0, TIT_STRING, []byte("test-topic"), 1, true)
+	pkt1 := NewSubscribe(0, TIT_STRING, "test-topic", 1, true)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Subscribe))
 }
 
 func TestSubscribeMarshalShort(t *testing.T) {
-	pkt1 := NewSubscribe(123, TIT_SHORT, nil, 1, true)
+	pkt1 := NewSubscribe(123, TIT_SHORT, "", 1, true)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Subscribe))

--- a/packets1/unsubscribe_test.go
+++ b/packets1/unsubscribe_test.go
@@ -10,7 +10,7 @@ import (
 func TestUnsubscribeStruct(t *testing.T) {
 	topicID := uint16(12)
 	topicIDType := TIT_REGISTERED
-	topicName := []byte("test-topic")
+	topicName := "test-topic"
 	pkt := NewUnsubscribe(topicID, topicIDType, topicName)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
@@ -23,14 +23,14 @@ func TestUnsubscribeStruct(t *testing.T) {
 }
 
 func TestUnsubscribeMarshalString(t *testing.T) {
-	pkt1 := NewUnsubscribe(0, TIT_STRING, []byte("test-topic"))
+	pkt1 := NewUnsubscribe(0, TIT_STRING, "test-topic")
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
 }
 
 func TestUnsubscribeMarshalShort(t *testing.T) {
-	pkt1 := NewUnsubscribe(123, TIT_SHORT, nil)
+	pkt1 := NewUnsubscribe(123, TIT_SHORT, "")
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))

--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -12,11 +12,11 @@ type WillTopicUpd struct {
 	pkts.Header
 	QOS       uint8
 	Retain    bool
-	WillTopic []byte
+	WillTopic string
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewWillTopicUpd(willTopic []byte, qos uint8, retain bool) *WillTopicUpd {
+func NewWillTopicUpd(willTopic string, qos uint8, retain bool) *WillTopicUpd {
 	p := &WillTopicUpd{
 		Header:    *pkts.NewHeader(pkts.WILLTOPICUPD, 0),
 		QOS:       qos,
@@ -51,7 +51,7 @@ func (p *WillTopicUpd) Pack() ([]byte, error) {
 	buf := p.Header.PackToBuffer()
 
 	_ = buf.WriteByte(p.encodeFlags())
-	_, _ = buf.Write(p.WillTopic)
+	_, _ = buf.Write([]byte(p.WillTopic))
 
 	return buf.Bytes(), nil
 }
@@ -63,7 +63,7 @@ func (p *WillTopicUpd) Unpack(buf []byte) error {
 	}
 
 	p.decodeFlags(buf[0])
-	p.WillTopic = buf[1:]
+	p.WillTopic = string(buf[1:])
 
 	return nil
 }

--- a/packets1/willtopicupd_test.go
+++ b/packets1/willtopicupd_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestWillTopicUpdStruct(t *testing.T) {
-	willTopic := []byte("test-topic")
+	willTopic := "test-topic"
 	qos := uint8(1)
 	retain := true
 	pkt := NewWillTopicUpd(willTopic, qos, retain)
@@ -23,7 +23,7 @@ func TestWillTopicUpdStruct(t *testing.T) {
 }
 
 func TestWillTopicUpdMarshal(t *testing.T) {
-	pkt1 := NewWillTopicUpd([]byte("test-topic"), 1, true)
+	pkt1 := NewWillTopicUpd("test-topic", 1, true)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillTopicUpd))
 }


### PR DESCRIPTION
Topic should be a well-formed string, it doesn't make sense to define it as a byte array.

Merge after #38 