### PR TITLE
packets1: Unify constructors arguments order

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -363,7 +363,7 @@ func (c *Client) Register(topic string) error {
 func (c *Client) subscribe(topicName string, topicIDType uint8, topicID uint16, qos uint8, callback MessageHandlerFunc) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newSubscribeTransaction(c, msgID, callback)
-	subscribe := pkts1.NewSubscribe(topicID, topicIDType, topicName, qos, false)
+	subscribe := pkts1.NewSubscribe(topicName, topicID, false, qos, topicIDType)
 	subscribe.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, subscribe)

--- a/client/client.go
+++ b/client/client.go
@@ -298,10 +298,11 @@ func (c *Client) notifyStateChange(s util.ClientState) {
 // unless it's a PUBLISH packet with QoS = -1.
 func (c *Client) Connect() error {
 	connect := pkts1.NewConnect(
+		uint16(c.cfg.KeepAlive.Seconds()),
 		[]byte(c.cfg.ClientID),
-		c.cfg.CleanSession,
 		c.cfg.WillTopic != "",
-		uint16(c.cfg.KeepAlive.Seconds()))
+		c.cfg.CleanSession,
+	)
 
 	var auth *pkts1.Auth
 	if c.cfg.User != "" {

--- a/client/client.go
+++ b/client/client.go
@@ -398,7 +398,7 @@ func (c *Client) SubscribePredefined(topicID uint16, qos uint8, callback Message
 func (c *Client) unsubscribe(topicName string, topicIDType uint8, topicID uint16) error {
 	msgID, _ := c.msgID.Next()
 	transaction := newUnsubscribeTransaction(c, msgID)
-	unsubscribe := pkts1.NewUnsubscribe(topicID, topicIDType, topicName)
+	unsubscribe := pkts1.NewUnsubscribe(topicName, topicID, topicIDType)
 	unsubscribe.SetMessageID(msgID)
 	c.transactions.Store(msgID, transaction)
 	transaction.Proceed(nil, unsubscribe)

--- a/client/client.go
+++ b/client/client.go
@@ -429,7 +429,7 @@ func (c *Client) UnsubscribePredefined(topicID uint16) error {
 }
 
 func (c *Client) publish(topicIDType uint8, topicID uint16, qos uint8, retain bool, payload []byte) error {
-	publish := pkts1.NewPublish(topicID, topicIDType, payload, qos, retain, false)
+	publish := pkts1.NewPublish(topicID, payload, false, qos, retain, topicIDType)
 	msgID, _ := c.msgID.Next()
 	publish.SetMessageID(msgID)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -940,7 +940,7 @@ func TestSubscribeQOS0(t *testing.T) {
 		// client <--PUBLISH-- GW
 		msgID := uint16(123)
 		publish := pkts1.NewPublish(suback.TopicID,
-			pkts1.TIT_REGISTERED, []byte(""), qos, false, false)
+			[]byte(""), false, qos, false, pkts1.TIT_REGISTERED)
 		publish.SetMessageID(msgID)
 		stp.send(publish)
 
@@ -1008,7 +1008,7 @@ func TestSubscribeQOS1(t *testing.T) {
 		// client <--PUBLISH-- GW
 		msgID := uint16(123)
 		publish := pkts1.NewPublish(suback.TopicID,
-			pkts1.TIT_REGISTERED, []byte(""), qos, false, false)
+			[]byte(""), false, qos, false, pkts1.TIT_REGISTERED)
 		publish.SetMessageID(msgID)
 		stp.send(publish)
 
@@ -1081,7 +1081,7 @@ func TestSubscribeQOS2(t *testing.T) {
 		for i := uint(0); i < stp.client.cfg.RetryCount+1; i++ {
 			// client <--PUBLISH-- GW
 			publish := pkts1.NewPublish(suback.TopicID,
-				pkts1.TIT_REGISTERED, []byte(""), qos, false, false)
+				[]byte(""), false, qos, false, pkts1.TIT_REGISTERED)
 			publish.SetMessageID(msgID)
 			stp.send(publish)
 
@@ -1175,7 +1175,7 @@ func TestSubscribeWildcard(t *testing.T) {
 
 		// client <--PUBLISH-- GW
 		publish := pkts1.NewPublish(register.TopicID,
-			pkts1.TIT_REGISTERED, []byte(""), 0, false, false)
+			[]byte(""), false, 0, false, pkts1.TIT_REGISTERED)
 		stp.send(publish)
 
 		close(published)
@@ -1251,7 +1251,7 @@ func TestSubscribeShort(t *testing.T) {
 
 		// client <--PUBLISH-- GW
 		publish := pkts1.NewPublish(encodedTopic,
-			pkts1.TIT_SHORT, []byte(""), 0, false, false)
+			[]byte(""), false, 0, false, pkts1.TIT_SHORT)
 		stp.send(publish)
 
 		stp.disconnect()
@@ -1318,7 +1318,7 @@ func TestSubscribePredefined(t *testing.T) {
 
 		// client <--PUBLISH-- GW
 		publish := pkts1.NewPublish(topicID,
-			pkts1.TIT_PREDEFINED, []byte(""), 0, false, false)
+			[]byte(""), false, 0, false, pkts1.TIT_PREDEFINED)
 		stp.send(publish)
 
 		stp.disconnect()
@@ -1635,7 +1635,7 @@ func TestSleep(t *testing.T) {
 			// client <--PUBLISH-- GW
 			encodedTopic := pkts.EncodeShortTopic(topic)
 			publish := pkts1.NewPublish(encodedTopic,
-				pkts1.TIT_SHORT, []byte(""), 0, false, false)
+				[]byte(""), false, 0, false, pkts1.TIT_SHORT)
 			stp.send(publish)
 
 			// client <--PINGRESP-- GW

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -933,7 +933,7 @@ func TestSubscribeQOS0(t *testing.T) {
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(1, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(1, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1001,7 +1001,7 @@ func TestSubscribeQOS1(t *testing.T) {
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(1, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(1, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1073,7 +1073,7 @@ func TestSubscribeQOS2(t *testing.T) {
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(1, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(1, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1158,7 +1158,7 @@ func TestSubscribeWildcard(t *testing.T) {
 		assert.Equal(wildcard, subscribe.TopicName)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(0, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(0, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1245,7 +1245,7 @@ func TestSubscribeShort(t *testing.T) {
 		assert.Equal(encodedTopic, subscribe.TopicID)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(0, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(0, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1312,7 +1312,7 @@ func TestSubscribePredefined(t *testing.T) {
 		assert.Equal(topicID, subscribe.TopicID)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(0, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(0, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1378,7 +1378,7 @@ func TestUnsubscribeString(t *testing.T) {
 		assert.Equal(pkts1.TIT_STRING, subscribe.TopicIDType)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(1, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(1, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1442,7 +1442,7 @@ func TestUnsubscribeShort(t *testing.T) {
 		assert.Equal(encodedTopic, subscribe.TopicID)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(0, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(0, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 
@@ -1506,7 +1506,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 		assert.Equal(topicID, subscribe.TopicID)
 
 		// client <--SUBACK-- GW
-		suback := pkts1.NewSuback(0, 0, pkts1.RC_ACCEPTED)
+		suback := pkts1.NewSuback(0, pkts1.RC_ACCEPTED, 0)
 		suback.CopyMessageID(subscribe)
 		stp.send(suback)
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -130,11 +130,7 @@ func TestPubSubPredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-<<<<<<< HEAD
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
-=======
-	snSubscribe := snPkts1.NewSubscribe(nil, topicID, false, 0, snPkts1.TIT_PREDEFINED)
->>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
+	snSubscribe := snPkts1.NewSubscribe("", topicID, false, 0, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -205,11 +201,7 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-<<<<<<< HEAD
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
-=======
-	snSubscribe := snPkts1.NewSubscribe(nil, topicID, false, 0, snPkts1.TIT_PREDEFINED)
->>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
+	snSubscribe := snPkts1.NewSubscribe("", topicID, false, 0, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -286,12 +278,7 @@ func TestDisconnectedSubscribe(t *testing.T) {
 	defer stp.cancel()
 
 	stp.snSend(
-<<<<<<< HEAD
-		snPkts1.NewSubscribe(0, snPkts1.TIT_STRING,
-			"test-topic-0", 0, false),
-=======
-		snPkts1.NewSubscribe([]byte("test-topic-0"), 0, false, 0, snPkts1.TIT_STRING),
->>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
+		snPkts1.NewSubscribe("test-topic-0", 0, false, 0, snPkts1.TIT_STRING),
 		true,
 	)
 
@@ -909,7 +896,7 @@ func TestUnsubscribeString(t *testing.T) {
 	stp.subscribe(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(0, snPkts1.TIT_STRING, topic)
+	snUnsubscribe := snPkts1.NewUnsubscribe(topic, 0, snPkts1.TIT_STRING)
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -943,7 +930,7 @@ func TestUnsubscribeShort(t *testing.T) {
 	stp.subscribeShort(topic, 0)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(snPkts.EncodeShortTopic(topic), snPkts1.TIT_SHORT, "")
+	snUnsubscribe := snPkts1.NewUnsubscribe("", snPkts.EncodeShortTopic(topic), snPkts1.TIT_SHORT)
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -1006,7 +993,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 	assert.Equal(snPkts1.RC_ACCEPTED, snSuback.ReturnCode)
 
 	// client --UNSUBSCRIBE--> GW
-	snUnsubscribe := snPkts1.NewUnsubscribe(topicID, snPkts1.TIT_PREDEFINED, "")
+	snUnsubscribe := snPkts1.NewUnsubscribe("", topicID, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snUnsubscribe, true)
 
 	// GW --UNSUBSCRIBE--> MQTT broker
@@ -1517,11 +1504,7 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	assert := assert.New(stp.t)
 
 	// client --SUBSCRIBE--> GW
-<<<<<<< HEAD
-	snSubscribe := snPkts1.NewSubscribe(0, snPkts1.TIT_STRING, topic, qos, false)
-=======
-	snSubscribe := snPkts1.NewSubscribe([]byte(topic), 0, false, qos, snPkts1.TIT_STRING)
->>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
+	snSubscribe := snPkts1.NewSubscribe(topic, 0, false, qos, snPkts1.TIT_STRING)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -1558,11 +1541,7 @@ func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 
 	// client --SUBSCRIBE--> GW
 	topicID := snPkts.EncodeShortTopic(topic)
-<<<<<<< HEAD
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_SHORT, "", qos, false)
-=======
-	snSubscribe := snPkts1.NewSubscribe(nil, topicID, false, qos, snPkts1.TIT_SHORT)
->>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
+	snSubscribe := snPkts1.NewSubscribe("", topicID, false, qos, snPkts1.TIT_SHORT)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -130,7 +130,11 @@ func TestPubSubPredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
+<<<<<<< HEAD
 	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
+=======
+	snSubscribe := snPkts1.NewSubscribe(nil, topicID, false, 0, snPkts1.TIT_PREDEFINED)
+>>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -201,7 +205,11 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
+<<<<<<< HEAD
 	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
+=======
+	snSubscribe := snPkts1.NewSubscribe(nil, topicID, false, 0, snPkts1.TIT_PREDEFINED)
+>>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -278,8 +286,12 @@ func TestDisconnectedSubscribe(t *testing.T) {
 	defer stp.cancel()
 
 	stp.snSend(
+<<<<<<< HEAD
 		snPkts1.NewSubscribe(0, snPkts1.TIT_STRING,
 			"test-topic-0", 0, false),
+=======
+		snPkts1.NewSubscribe([]byte("test-topic-0"), 0, false, 0, snPkts1.TIT_STRING),
+>>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
 		true,
 	)
 
@@ -972,7 +984,7 @@ func TestUnsubscribePredefined(t *testing.T) {
 	// SUBSCRIBE, PREDEFINED TOPIC
 
 	// client --SUBSCRIBE--> GW
-	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_PREDEFINED, "", 0, false)
+	snSubscribe := snPkts1.NewSubscribe("", topicID, false, 0, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -1505,7 +1517,11 @@ func (stp *testSetup) subscribe(topic string, qos uint8) uint16 {
 	assert := assert.New(stp.t)
 
 	// client --SUBSCRIBE--> GW
+<<<<<<< HEAD
 	snSubscribe := snPkts1.NewSubscribe(0, snPkts1.TIT_STRING, topic, qos, false)
+=======
+	snSubscribe := snPkts1.NewSubscribe([]byte(topic), 0, false, qos, snPkts1.TIT_STRING)
+>>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker
@@ -1542,7 +1558,11 @@ func (stp *testSetup) subscribeShort(topic string, qos uint8) {
 
 	// client --SUBSCRIBE--> GW
 	topicID := snPkts.EncodeShortTopic(topic)
+<<<<<<< HEAD
 	snSubscribe := snPkts1.NewSubscribe(topicID, snPkts1.TIT_SHORT, "", qos, false)
+=======
+	snSubscribe := snPkts1.NewSubscribe(nil, topicID, false, qos, snPkts1.TIT_SHORT)
+>>>>>>> 4d06ebf... packets1: Change `Subscribe` constructor args order
 	stp.snSend(snSubscribe, true)
 
 	// GW --SUBSCRIBE--> MQTT broker

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -48,7 +48,7 @@ func TestRepeatedConnect(t *testing.T) {
 	defer stp.cancel()
 
 	// client --CONNECT--> GW
-	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(1, clientID, false, true)
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker
@@ -1031,7 +1031,7 @@ func TestLastWill(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts1.NewConnect(clientID, true, true, keepalive)
+	snConnect := snPkts1.NewConnect(keepalive, clientID, true, true)
 	stp.snSend(snConnect, false)
 
 	// client <--WILLTOPICREQ-- GW
@@ -1111,7 +1111,7 @@ func TestConnectTimeout(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts1.NewConnect(clientID, true, true, 2)
+	snConnect := snPkts1.NewConnect(2, clientID, true, true)
 	stp.snSend(snConnect, false)
 
 	// client <--WILLTOPICREQ-- GW
@@ -1138,7 +1138,7 @@ func TestAuthSuccess(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(1, clientID, false, true)
 	stp.snSend(snConnect, false)
 
 	// client --AUTH--> GW
@@ -1182,7 +1182,7 @@ func TestAuthFail(t *testing.T) {
 	// CONNECT
 
 	// client --CONNECT--> GW
-	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(1, clientID, false, true)
 	stp.snSend(snConnect, false)
 
 	// client --AUTH--> GW
@@ -1459,7 +1459,7 @@ func (stp *testSetup) connect() {
 	clientID := []byte("test-client")
 
 	// client --CONNECT--> GW
-	snConnect := snPkts1.NewConnect(clientID, true, false, 1)
+	snConnect := snPkts1.NewConnect(1, clientID, false, true)
 	stp.snSend(snConnect, false)
 
 	// GW --CONNECT--> MQTT broker

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -156,7 +156,7 @@ func TestPubSubPredefined(t *testing.T) {
 	payload := []byte("test-msg-1")
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_PREDEFINED, payload, 0, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload, false, 0, false, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -233,7 +233,7 @@ func TestPubSubPredefinedLong(t *testing.T) {
 	}
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_PREDEFINED, payload, 0, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload, false, 0, false, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -293,9 +293,8 @@ func TestDisconnectedPublishQOS0(t *testing.T) {
 	defer stp.cancel()
 
 	snPublish := snPkts1.NewPublish(
-		snPkts.EncodeShortTopic("ab"),
-		snPkts1.TIT_SHORT, []byte("test-payload"), 0, false, false,
-	)
+		snPkts.EncodeShortTopic("ab"), []byte("test-payload"),
+		false, 0, false, snPkts1.TIT_SHORT)
 	stp.snSend(snPublish, true)
 
 	stp.assertHandlerDone()
@@ -308,7 +307,8 @@ func TestDisconnectedPublishQOS3Registered(t *testing.T) {
 	defer stp.cancel()
 
 	snPublish := snPkts1.NewPublish(
-		123, snPkts1.TIT_REGISTERED, []byte("test-payload"), 3, false, false)
+		123, []byte("test-payload"),
+		false, 3, false, snPkts1.TIT_REGISTERED)
 	stp.snSend(snPublish, true)
 
 	stp.assertHandlerDone()
@@ -325,8 +325,8 @@ func TestDisconnectedAuthPublishQOS3Registered(t *testing.T) {
 	payload := []byte("test-msg-0")
 	qos := uint8(3)
 
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_SHORT,
-		payload, qos, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload,
+		false, qos, false, snPkts1.TIT_SHORT)
 	stp.snSend(snPublish, true)
 
 	stp.assertHandlerDone()
@@ -346,8 +346,8 @@ func TestDisconnectedPublishQOS3Short(t *testing.T) {
 	qos := uint8(3)
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_SHORT,
-		payload, qos, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload,
+		false, qos, false, snPkts1.TIT_SHORT)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -378,8 +378,8 @@ func TestDisconnectedPublishQOS3Predefined(t *testing.T) {
 	defer stp.cancel()
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_PREDEFINED,
-		payload, qos, false, false)
+	snPublish := snPkts1.NewPublish(topicID,
+		payload, false, qos, false, snPkts1.TIT_PREDEFINED)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -406,7 +406,7 @@ func TestClientPublishQOS0(t *testing.T) {
 	topicID := stp.register(topic)
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_REGISTERED, payload, 0, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload, false, 0, false, snPkts1.TIT_REGISTERED)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -436,7 +436,7 @@ func TestClientPublishQOS1(t *testing.T) {
 	payload = []byte("test-msg-1")
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_REGISTERED, payload, 1, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload, false, 1, false, snPkts1.TIT_REGISTERED)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker
@@ -475,7 +475,7 @@ func TestClientPublishQOS2(t *testing.T) {
 	payload = []byte("test-msg-2")
 
 	// client --PUBLISH--> GW
-	snPublish := snPkts1.NewPublish(topicID, snPkts1.TIT_REGISTERED, payload, 2, false, false)
+	snPublish := snPkts1.NewPublish(topicID, payload, false, 2, false, snPkts1.TIT_REGISTERED)
 	stp.snSend(snPublish, true)
 
 	// GW --PUBLISH--> MQTT broker

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -587,7 +587,7 @@ func (h *handler1) handleSubscribe(ctx context.Context, snSubscribe *snPkts1.Sub
 			var err error
 			topicID, err = h.newTopicID()
 			if err != nil {
-				snSuback := snPkts1.NewSuback(0, 0, snPkts1.RC_INVALID_TOPIC_ID)
+				snSuback := snPkts1.NewSuback(0, snPkts1.RC_INVALID_TOPIC_ID, 0)
 				// We are kind of misusing the "invalid topic ID" return code here.
 				// Please see note in `case *snPkts.Register`.
 				snSuback.CopyMessageID(snSubscribe)

--- a/gateway/handler1.go
+++ b/gateway/handler1.go
@@ -275,8 +275,8 @@ func (h *handler1) handleBrokerPublish(ctx context.Context, mqPublish *mqPkts.Pu
 		needsRegister = !ok
 	}
 
-	snPublish := snPkts1.NewPublish(topicID, topicIDType,
-		mqPublish.Payload, mqPublish.Qos, mqPublish.Retain, mqPublish.Dup)
+	snPublish := snPkts1.NewPublish(topicID, mqPublish.Payload, mqPublish.Dup,
+		mqPublish.Qos, mqPublish.Retain, topicIDType)
 	snPublish.SetMessageID(mqPublish.MessageID)
 
 	if mqPublish.Qos == 0 {

--- a/gateway/subscribe_transaction.go
+++ b/gateway/subscribe_transaction.go
@@ -54,7 +54,7 @@ func (t *subscribeTransaction) Suback(mqSuback *mqPkts.SubackPacket) error {
 		returnCode = snPkts1.RC_NOT_SUPPORTED
 		t.Fail(fmt.Errorf("MQTT SUBACK return code: %d", mqSuback.ReturnCodes[0]))
 	}
-	snPkt := snPkts1.NewSuback(t.topicID, mqSuback.Qos, returnCode)
+	snPkt := snPkts1.NewSuback(t.topicID, returnCode, mqSuback.Qos)
 	snPkt.SetMessageID(mqSuback.MessageID)
 	return t.handler.snSend(snPkt)
 }

--- a/packets1/connect.go
+++ b/packets1/connect.go
@@ -19,7 +19,7 @@ type Connect struct {
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewConnect(clientID []byte, cleanSession bool, will bool, duration uint16) *Connect {
+func NewConnect(duration uint16, clientID []byte, will bool, cleanSession bool) *Connect {
 	p := &Connect{
 		Header:       *pkts.NewHeader(pkts.CONNECT, 0),
 		Will:         will,

--- a/packets1/connect_test.go
+++ b/packets1/connect_test.go
@@ -12,7 +12,7 @@ func TestConnect(t *testing.T) {
 	cleanSession := true
 	will := true
 	duration := uint16(90)
-	pkt := NewConnect(clientID, cleanSession, will, duration)
+	pkt := NewConnect(duration, clientID, will, cleanSession)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
 		assert.Equal(t, "*packets1.Connect", reflect.TypeOf(pkt).String(), "Type should be Connect")
@@ -25,7 +25,7 @@ func TestConnect(t *testing.T) {
 }
 
 func TestConnectMarshal(t *testing.T) {
-	pkt1 := NewConnect([]byte("test-client"), true, true, 75)
+	pkt1 := NewConnect(75, []byte("test-client"), true, true)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Connect))
 }

--- a/packets1/publish.go
+++ b/packets1/publish.go
@@ -21,8 +21,8 @@ type Publish struct {
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewPublish(topicID uint16, topicIDType uint8, payload []byte, qos uint8,
-	retain bool, dup bool) *Publish {
+func NewPublish(topicID uint16, payload []byte, dup bool, qos uint8, retain bool,
+	topicIDType uint8) *Publish {
 	p := &Publish{
 		Header:      *pkts.NewHeader(pkts.PUBLISH, 0),
 		DUPProperty: *pkts.NewDUPProperty(dup),

--- a/packets1/publish_test.go
+++ b/packets1/publish_test.go
@@ -14,7 +14,7 @@ func TestPublishStruct(t *testing.T) {
 	topicIDType := TIT_SHORT
 	topicID := uint16(123)
 	payload := []byte("test-payload")
-	pkt := NewPublish(topicID, topicIDType, payload, qos, retain, dup)
+	pkt := NewPublish(topicID, payload, dup, qos, retain, topicIDType)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
 		assert.Equal(t, "*packets1.Publish", reflect.TypeOf(pkt).String(), "Type should be Publish")
@@ -29,8 +29,7 @@ func TestPublishStruct(t *testing.T) {
 }
 
 func TestPublishMarshal(t *testing.T) {
-	pkt1 := NewPublish(123, TIT_PREDEFINED,
-		[]byte("test-payload"), 1, true, true)
+	pkt1 := NewPublish(123, []byte("test-payload"), true, 1, true, TIT_PREDEFINED)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Publish))

--- a/packets1/suback.go
+++ b/packets1/suback.go
@@ -17,7 +17,7 @@ type Suback struct {
 	TopicID    uint16
 }
 
-func NewSuback(topicID uint16, qos uint8, returnCode ReturnCode) *Suback {
+func NewSuback(topicID uint16, returnCode ReturnCode, qos uint8) *Suback {
 	return &Suback{
 		Header:     *pkts.NewHeader(pkts.SUBACK, subackVarPartLength),
 		QOS:        qos,

--- a/packets1/suback_test.go
+++ b/packets1/suback_test.go
@@ -11,7 +11,7 @@ func TestSubackStruct(t *testing.T) {
 	topicID := uint16(12)
 	qos := uint8(1)
 	returnCode := RC_ACCEPTED
-	pkt := NewSuback(topicID, qos, returnCode)
+	pkt := NewSuback(topicID, returnCode, qos)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
 		assert.Equal(t, "*packets1.Suback", reflect.TypeOf(pkt).String(), "Type should be Suback")
@@ -24,7 +24,7 @@ func TestSubackStruct(t *testing.T) {
 }
 
 func TestSubackMarshal(t *testing.T) {
-	pkt1 := NewSuback(123, 1, RC_CONGESTION)
+	pkt1 := NewSuback(123, RC_CONGESTION, 1)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Suback))

--- a/packets1/subscribe.go
+++ b/packets1/subscribe.go
@@ -20,7 +20,7 @@ type Subscribe struct {
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewSubscribe(topicID uint16, topicIDType uint8, topicName string, qos uint8, dup bool) *Subscribe {
+func NewSubscribe(topicName string, topicID uint16, dup bool, qos uint8, topicIDType uint8) *Subscribe {
 	p := &Subscribe{
 		Header:      *pkts.NewHeader(pkts.SUBSCRIBE, 0),
 		DUPProperty: *pkts.NewDUPProperty(dup),

--- a/packets1/subscribe_test.go
+++ b/packets1/subscribe_test.go
@@ -13,7 +13,7 @@ func TestSubscribeStruct(t *testing.T) {
 	topicName := "test-topic"
 	qos := uint8(1)
 	dup := true
-	pkt := NewSubscribe(topicID, topicIDType, topicName, qos, dup)
+	pkt := NewSubscribe(topicName, topicID, dup, qos, topicIDType)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
 		assert.Equal(t, "*packets1.Subscribe", reflect.TypeOf(pkt).String(), "Type should be Subscribe")
@@ -27,14 +27,14 @@ func TestSubscribeStruct(t *testing.T) {
 }
 
 func TestSubscribeMarshalString(t *testing.T) {
-	pkt1 := NewSubscribe(0, TIT_STRING, "test-topic", 1, true)
+	pkt1 := NewSubscribe("test-topic", 0, true, 1, TIT_STRING)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Subscribe))
 }
 
 func TestSubscribeMarshalShort(t *testing.T) {
-	pkt1 := NewSubscribe(123, TIT_SHORT, "", 1, true)
+	pkt1 := NewSubscribe("", 123, true, 1, TIT_SHORT)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Subscribe))

--- a/packets1/unsubscribe.go
+++ b/packets1/unsubscribe.go
@@ -18,7 +18,7 @@ type Unsubscribe struct {
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewUnsubscribe(topicID uint16, topicIDType uint8, topicName string) *Unsubscribe {
+func NewUnsubscribe(topicName string, topicID uint16, topicIDType uint8) *Unsubscribe {
 	p := &Unsubscribe{
 		Header:      *pkts.NewHeader(pkts.UNSUBSCRIBE, 0),
 		TopicIDType: topicIDType,

--- a/packets1/unsubscribe_test.go
+++ b/packets1/unsubscribe_test.go
@@ -11,7 +11,7 @@ func TestUnsubscribeStruct(t *testing.T) {
 	topicID := uint16(12)
 	topicIDType := TIT_REGISTERED
 	topicName := "test-topic"
-	pkt := NewUnsubscribe(topicID, topicIDType, topicName)
+	pkt := NewUnsubscribe(topicName, topicID, topicIDType)
 
 	if assert.NotNil(t, pkt, "New packet should not be nil") {
 		assert.Equal(t, "*packets1.Unsubscribe", reflect.TypeOf(pkt).String(), "Type should be Unsubscribe")
@@ -23,14 +23,14 @@ func TestUnsubscribeStruct(t *testing.T) {
 }
 
 func TestUnsubscribeMarshalString(t *testing.T) {
-	pkt1 := NewUnsubscribe(0, TIT_STRING, "test-topic")
+	pkt1 := NewUnsubscribe("test-topic", 0, TIT_STRING)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
 }
 
 func TestUnsubscribeMarshalShort(t *testing.T) {
-	pkt1 := NewUnsubscribe(123, TIT_SHORT, "")
+	pkt1 := NewUnsubscribe("", 123, TIT_SHORT)
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))


### PR DESCRIPTION
Arguments order should match the order of the packet's fields as defined
in the specification. Flags are placed at the end of the args list.