### PR TITLE
client: Change methods args order

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -482,7 +482,7 @@ func (c *Client) Publish(topic string, payload []byte, qos uint8, retain bool) e
 }
 
 // PublishPredefined publishes a message to the provided predefined topic.
-func (c *Client) PublishPredefined(topicID uint16, qos uint8, retain bool, payload []byte) error {
+func (c *Client) PublishPredefined(topicID uint16, payload []byte, qos uint8, retain bool) error {
 	return c.publish(pkts1.TIT_PREDEFINED, topicID, qos, retain, payload)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -462,7 +462,7 @@ func (c *Client) publish(topicIDType uint8, topicID uint16, qos uint8, retain bo
 }
 
 // Publish publishes a message to the provided topic.
-func (c *Client) Publish(topic string, qos uint8, retain bool, payload []byte) error {
+func (c *Client) Publish(topic string, payload []byte, qos uint8, retain bool) error {
 	var topicIDType uint8
 	var topicID uint16
 	if pkts.IsShortTopic(topic) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -359,7 +359,7 @@ func TestPublishQOS0Predefined(t *testing.T) {
 	}
 	assert.Equal(util.StateActive, stp.client.state.Get())
 
-	if err := stp.client.PublishPredefined(topicID, qos, retain, payload); err != nil {
+	if err := stp.client.PublishPredefined(topicID, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -555,7 +555,7 @@ func TestPublishQOS1Predefined(t *testing.T) {
 	}
 	assert.Equal(util.StateActive, stp.client.state.Get())
 
-	if err := stp.client.PublishPredefined(topicID, qos, retain, payload); err != nil {
+	if err := stp.client.PublishPredefined(topicID, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -787,7 +787,7 @@ func TestPublishQOS2Predefined(t *testing.T) {
 	}
 	assert.Equal(util.StateActive, stp.client.state.Get())
 
-	if err := stp.client.PublishPredefined(topicID, qos, retain, payload); err != nil {
+	if err := stp.client.PublishPredefined(topicID, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -902,7 +902,7 @@ func TestPublishQOS3(t *testing.T) {
 		assert.Equal(qos, publish.QOS)
 	}()
 
-	if err := stp.client.PublishPredefined(topicID, qos, retain, payload); err != nil {
+	if err := stp.client.PublishPredefined(topicID, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -311,7 +311,7 @@ func TestPublishQOS0(t *testing.T) {
 		stp.t.Fatal(err)
 	}
 
-	if err := stp.client.Publish(topic, qos, retain, payload); err != nil {
+	if err := stp.client.Publish(topic, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -408,7 +408,7 @@ func TestPublishQOS0Short(t *testing.T) {
 	}
 	assert.Equal(util.StateActive, stp.client.state.Get())
 
-	if err := stp.client.Publish(topic, qos, retain, payload); err != nil {
+	if err := stp.client.Publish(topic, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -489,7 +489,7 @@ func TestPublishQOS1(t *testing.T) {
 		stp.t.Fatal(err)
 	}
 
-	if err := stp.client.Publish(topic, qos, retain, payload); err != nil {
+	if err := stp.client.Publish(topic, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -622,7 +622,7 @@ func TestPublishQOS1Short(t *testing.T) {
 	}
 	assert.Equal(util.StateActive, stp.client.state.Get())
 
-	if err := stp.client.Publish(topic, qos, retain, payload); err != nil {
+	if err := stp.client.Publish(topic, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -712,7 +712,7 @@ func TestPublishQOS2(t *testing.T) {
 		stp.t.Fatal(err)
 	}
 
-	if err := stp.client.Publish(topic, qos, retain, payload); err != nil {
+	if err := stp.client.Publish(topic, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 
@@ -863,7 +863,7 @@ func TestPublishQOS2Short(t *testing.T) {
 	}
 	assert.Equal(util.StateActive, stp.client.state.Get())
 
-	if err := stp.client.Publish(topic, qos, retain, payload); err != nil {
+	if err := stp.client.Publish(topic, payload, qos, retain); err != nil {
 		stp.t.Fatal(err)
 	}
 

--- a/cmd/bisquitt-pub/actions.go
+++ b/cmd/bisquitt-pub/actions.go
@@ -187,7 +187,7 @@ func handleAction() cli.ActionFunc {
 
 		topicID, isPredefinedTopic := predefinedTopics.GetTopicID(clientID, topic)
 		if isPredefinedTopic {
-			if err := client.PublishPredefined(topicID, qos, retain, payload); err != nil {
+			if err := client.PublishPredefined(topicID, payload, qos, retain); err != nil {
 				return err
 			}
 		} else {

--- a/cmd/bisquitt-pub/actions.go
+++ b/cmd/bisquitt-pub/actions.go
@@ -200,7 +200,7 @@ func handleAction() cli.ActionFunc {
 				return err
 			}
 
-			if err := client.Publish(topic, qos, retain, payload); err != nil {
+			if err := client.Publish(topic, payload, qos, retain); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Place the most important args first and flags last (in the order as specified in the packet format specification).