### PR TITLE
packets1: Unify structs fields order

### DIFF
--- a/packets1/advertise.go
+++ b/packets1/advertise.go
@@ -11,6 +11,7 @@ const advertiseVarPartLength uint16 = 3
 
 type Advertise struct {
 	pkts.Header
+	// Fields
 	GatewayID uint8
 	Duration  uint16
 }

--- a/packets1/auth.go
+++ b/packets1/auth.go
@@ -29,6 +29,7 @@ const authHeaderLength uint16 = 2
 // SASL PLAIN method specification: https://datatracker.ietf.org/doc/html/rfc4616
 type Auth struct {
 	pkts.Header
+	// Fields
 	Reason uint8
 	Method string
 	Data   []byte

--- a/packets1/connack.go
+++ b/packets1/connack.go
@@ -10,6 +10,7 @@ const connackVarPartLength uint16 = 1
 
 type Connack struct {
 	pkts.Header
+	// Fields
 	ReturnCode ReturnCode
 }
 

--- a/packets1/connect.go
+++ b/packets1/connect.go
@@ -11,11 +11,13 @@ const connectHeaderLength uint16 = 4
 
 type Connect struct {
 	pkts.Header
-	CleanSession bool
-	ClientID     []byte
-	Duration     uint16
-	ProtocolID   uint8
+	// Flags
 	Will         bool
+	CleanSession bool
+	// Fields
+	ProtocolID uint8
+	Duration   uint16
+	ClientID   []byte
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().

--- a/packets1/disconnect.go
+++ b/packets1/disconnect.go
@@ -11,6 +11,7 @@ const disconnectDurationLength uint16 = 2
 
 type Disconnect struct {
 	pkts.Header
+	// Fields
 	Duration uint16
 }
 

--- a/packets1/gwinfo.go
+++ b/packets1/gwinfo.go
@@ -10,6 +10,7 @@ const gwInfoHeaderLength uint16 = 1
 
 type GwInfo struct {
 	pkts.Header
+	// Fields
 	GatewayID      uint8
 	GatewayAddress []byte
 }

--- a/packets1/pingreq.go
+++ b/packets1/pingreq.go
@@ -8,6 +8,7 @@ import (
 
 type Pingreq struct {
 	pkts.Header
+	// Fields
 	ClientID []byte
 }
 

--- a/packets1/puback.go
+++ b/packets1/puback.go
@@ -11,8 +11,9 @@ const pubackVarPartLength uint16 = 5
 
 type Puback struct {
 	pkts.Header
+	// Fields
+	TopicID uint16
 	MessageIDProperty
-	TopicID    uint16
 	ReturnCode ReturnCode
 }
 

--- a/packets1/pubcomp.go
+++ b/packets1/pubcomp.go
@@ -11,6 +11,7 @@ const pubcompVarPartLength uint16 = 2
 
 type Pubcomp struct {
 	pkts.Header
+	// Fields
 	MessageIDProperty
 }
 

--- a/packets1/publish.go
+++ b/packets1/publish.go
@@ -11,13 +11,15 @@ const publishHeaderLength uint16 = 5
 
 type Publish struct {
 	pkts.Header
-	MessageIDProperty
+	// Flags
 	pkts.DUPProperty
-	Retain      bool
 	QOS         uint8
+	Retain      bool
 	TopicIDType uint8
-	TopicID     uint16
-	Data        []byte
+	// Fields
+	TopicID uint16
+	MessageIDProperty
+	Data []byte
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
@@ -26,11 +28,11 @@ func NewPublish(topicID uint16, payload []byte, dup bool, qos uint8, retain bool
 	p := &Publish{
 		Header:      *pkts.NewHeader(pkts.PUBLISH, 0),
 		DUPProperty: *pkts.NewDUPProperty(dup),
-		TopicID:     topicID,
-		TopicIDType: topicIDType,
-		Data:        payload,
 		QOS:         qos,
 		Retain:      retain,
+		TopicIDType: topicIDType,
+		TopicID:     topicID,
+		Data:        payload,
 	}
 	p.computeLength()
 	return p

--- a/packets1/pubrec.go
+++ b/packets1/pubrec.go
@@ -11,6 +11,7 @@ const pubrecVarPartLength uint16 = 2
 
 type Pubrec struct {
 	pkts.Header
+	// Fields
 	MessageIDProperty
 }
 

--- a/packets1/pubrel.go
+++ b/packets1/pubrel.go
@@ -11,6 +11,7 @@ const pubrelVarPartLength uint16 = 2
 
 type Pubrel struct {
 	pkts.Header
+	// Fields
 	MessageIDProperty
 }
 

--- a/packets1/regack.go
+++ b/packets1/regack.go
@@ -11,8 +11,9 @@ const regackVarPartLength uint16 = 5
 
 type Regack struct {
 	pkts.Header
+	// Fields
+	TopicID uint16
 	MessageIDProperty
-	TopicID    uint16
 	ReturnCode ReturnCode
 }
 

--- a/packets1/register.go
+++ b/packets1/register.go
@@ -11,8 +11,9 @@ const registerHeaderLength uint16 = 4
 
 type Register struct {
 	pkts.Header
+	// Fields
+	TopicID uint16
 	MessageIDProperty
-	TopicID   uint16
 	TopicName string
 }
 

--- a/packets1/searchgw.go
+++ b/packets1/searchgw.go
@@ -10,6 +10,7 @@ const searchGwVarPartLength uint16 = 1
 
 type SearchGw struct {
 	pkts.Header
+	// Fields
 	Radius uint8
 }
 

--- a/packets1/suback.go
+++ b/packets1/suback.go
@@ -11,18 +11,20 @@ const subackVarPartLength uint16 = 6
 
 type Suback struct {
 	pkts.Header
+	// Flags
+	QOS uint8
+	// Fields
+	TopicID uint16
 	MessageIDProperty
-	QOS        uint8
 	ReturnCode ReturnCode
-	TopicID    uint16
 }
 
 func NewSuback(topicID uint16, returnCode ReturnCode, qos uint8) *Suback {
 	return &Suback{
 		Header:     *pkts.NewHeader(pkts.SUBACK, subackVarPartLength),
 		QOS:        qos,
-		ReturnCode: returnCode,
 		TopicID:    topicID,
+		ReturnCode: returnCode,
 	}
 }
 

--- a/packets1/subscribe.go
+++ b/packets1/subscribe.go
@@ -11,12 +11,14 @@ const subscribeHeaderLength uint16 = 3
 
 type Subscribe struct {
 	pkts.Header
+	// Flags
 	pkts.DUPProperty
-	MessageIDProperty
 	QOS         uint8
 	TopicIDType uint8
-	TopicID     uint16
-	TopicName   string
+	// Fields
+	MessageIDProperty
+	TopicID   uint16
+	TopicName string
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().

--- a/packets1/unsuback.go
+++ b/packets1/unsuback.go
@@ -11,6 +11,7 @@ const unsubackVarPartLength uint16 = 2
 
 type Unsuback struct {
 	pkts.Header
+	// Fields
 	MessageIDProperty
 }
 

--- a/packets1/unsubscribe.go
+++ b/packets1/unsubscribe.go
@@ -11,10 +11,12 @@ const unsubscribeHeaderLength uint16 = 3
 
 type Unsubscribe struct {
 	pkts.Header
-	MessageIDProperty
+	// Flags
 	TopicIDType uint8
-	TopicID     uint16
-	TopicName   string
+	// Fields
+	MessageIDProperty
+	TopicID   uint16
+	TopicName string
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().

--- a/packets1/willmsg.go
+++ b/packets1/willmsg.go
@@ -8,6 +8,7 @@ import (
 
 type WillMsg struct {
 	pkts.Header
+	// Fields
 	WillMsg []byte
 }
 

--- a/packets1/willmsgresp.go
+++ b/packets1/willmsgresp.go
@@ -10,6 +10,7 @@ const willMsgRespVarPartLength uint16 = 1
 
 type WillMsgResp struct {
 	pkts.Header
+	// Fields
 	ReturnCode ReturnCode
 }
 

--- a/packets1/willmsgupd.go
+++ b/packets1/willmsgupd.go
@@ -8,6 +8,7 @@ import (
 
 type WillMsgUpd struct {
 	pkts.Header
+	// Fields
 	WillMsg []byte
 }
 

--- a/packets1/willtopic.go
+++ b/packets1/willtopic.go
@@ -10,8 +10,10 @@ const willTopicFlagsLength uint16 = 1
 
 type WillTopic struct {
 	pkts.Header
-	QOS       uint8
-	Retain    bool
+	// Flags
+	QOS    uint8
+	Retain bool
+	// Fields
 	WillTopic string
 }
 

--- a/packets1/willtopicresp.go
+++ b/packets1/willtopicresp.go
@@ -10,6 +10,7 @@ const willTopicRespVarPartLength uint16 = 1
 
 type WillTopicResp struct {
 	pkts.Header
+	// Fields
 	ReturnCode ReturnCode
 }
 

--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -10,8 +10,10 @@ const willTopicUpdHeaderLength uint16 = 1
 
 type WillTopicUpd struct {
 	pkts.Header
-	QOS       uint8
-	Retain    bool
+	// Flags
+	QOS    uint8
+	Retain bool
+	// Fields
 	WillTopic string
 }
 


### PR DESCRIPTION
Makes structs more readable and conforming to the specification.

- add `Flags` and `Fields` comments
- change structs fields order to reflect the order of packet fields in the specification

...i.e. make fields order the same as constructor args order introduced in #41 