### PR TITLE
packets1: Return `Unpack()` errors from `ReadPacket()`

### DIFF
--- a/packets1/packets1.go
+++ b/packets1/packets1.go
@@ -80,12 +80,16 @@ func ReadPacket(r io.Reader) (pkt pkts.Packet, err error) {
 		return nil, err
 	}
 	packet = packet[:n]
-	h.Unpack(packet)
+	if err := h.Unpack(packet); err != nil {
+		return nil, err
+	}
 	pkt = NewPacketWithHeader(h)
 	if pkt == nil {
-		return nil, errors.New("invalid MQTT-SN packet")
+		return nil, errors.New("invalid MQTT-SN packet type")
 	}
-	pkt.Unpack(packet[h.HeaderLength():])
+	if err := pkt.Unpack(packet[h.HeaderLength():]); err != nil {
+		return nil, err
+	}
 
 	return pkt, nil
 }

--- a/packets1/packets1_test.go
+++ b/packets1/packets1_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
@@ -20,4 +22,26 @@ func testPacketMarshal(t *testing.T, pkt1 pkts.Packet) pkts.Packet {
 	}
 
 	return pkt2
+}
+
+func TestUnmarshalShortPacket(t *testing.T) {
+	buff := bytes.NewBuffer([]byte{
+		1, // Length
+		// MsgType missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad packet length")
+	}
+}
+
+func TestUnmarshalInvalidPacketType(t *testing.T) {
+	buff := bytes.NewBuffer([]byte{
+		2,          // Length
+		byte(0x19), // invalid MsgType
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Equal(t, err.Error(), "invalid MQTT-SN packet type")
+	}
 }

--- a/packets1/willmsgreq.go
+++ b/packets1/willmsgreq.go
@@ -24,7 +24,7 @@ func (p *WillMsgReq) Pack() ([]byte, error) {
 }
 
 func (p *WillMsgReq) Unpack(buf []byte) error {
-	if len(buf) <= int(willMsgReqVarPartLength) {
+	if len(buf) != int(willMsgReqVarPartLength) {
 		return fmt.Errorf("bad WILLMSGREQ packet length: expected %d, got %d",
 			willMsgReqVarPartLength, len(buf))
 	}


### PR DESCRIPTION
Possible `pkt.Unpack()` error was incorrectly ignored in `ReadPacket()`. First commit fixes it and also adds a new test for incorrect packet type unmarshalling.

This `ReadPacket()` fix also revealed a bug in `WillMsgReq.Unpack()`. It's a one-line fix, so I include it in this PR also.