### PR TITLE
Make `packets1.DecodePlain` an `Auth` method

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -163,7 +163,7 @@ func TestConnectAuthWill(t *testing.T) {
 		// client --AUTH--> GW
 		auth := stp.recv().(*pkts1.Auth)
 		assert.Equal(pkts1.AUTH_PLAIN, auth.Method)
-		authUser, authPassword, err := pkts1.DecodePlain(auth)
+		authUser, authPassword, err := auth.DecodePlain()
 		assert.Equal(user, authUser)
 		assert.Equal(password, authPassword)
 		assert.Nil(err)

--- a/gateway/connect_transaction.go
+++ b/gateway/connect_transaction.go
@@ -83,7 +83,7 @@ func (t *connectTransaction) Start(ctx context.Context) error {
 func (t *connectTransaction) Auth(snPkt *snPkts1.Auth) error {
 	// Extract username and password from PLAIN data.
 	if snPkt.Method == snPkts1.AUTH_PLAIN {
-		user, password, err := snPkts1.DecodePlain(snPkt)
+		user, password, err := snPkt.DecodePlain()
 		if err != nil {
 			t.Fail(err)
 			return err

--- a/packets1/auth.go
+++ b/packets1/auth.go
@@ -52,10 +52,10 @@ func NewAuthPlain(user string, password []byte) *Auth {
 
 // DecodePlain decodes username and password from AUTH package data encoded
 // using "PLAIN" method.
-func DecodePlain(auth *Auth) (string, []byte, error) {
-	dataParts := bytes.Split(auth.Data, []byte{0})
+func (p *Auth) DecodePlain() (string, []byte, error) {
+	dataParts := bytes.Split(p.Data, []byte{0})
 	if len(dataParts) != 3 {
-		return "", nil, fmt.Errorf("invalid PLAIN auth data format: %v.", auth.Data)
+		return "", nil, fmt.Errorf("invalid PLAIN auth data format: %v.", p.Data)
 	}
 	// NOTE: PLAIN first part (authorization identity) not used.
 	return string(dataParts[1]), dataParts[2], nil


### PR DESCRIPTION
`DecodePlain` takes `*Auth` as a parameter anyway, so it would be better to declare it as `Auth` method.