### PR TITLE
packets1: Add full-coverage `Connect` unit tests

### DIFF
--- a/packets1/connect.go
+++ b/packets1/connect.go
@@ -62,7 +62,7 @@ func (p *Connect) Pack() ([]byte, error) {
 	_ = buf.WriteByte(p.encodeFlags())
 	_ = buf.WriteByte(p.ProtocolID)
 	_, _ = buf.Write(pkts.EncodeUint16(p.Duration))
-	_, _ = buf.Write([]byte(p.ClientID))
+	_, _ = buf.Write(p.ClientID)
 
 	return buf.Bytes(), nil
 }

--- a/packets1/connect.go
+++ b/packets1/connect.go
@@ -71,8 +71,12 @@ func (p *Connect) Unpack(buf []byte) error {
 	if len(buf) < int(connectHeaderLength+1) {
 		return fmt.Errorf("bad CONNECT packet length: expected >=%d, got %d", connectHeaderLength+1, len(buf))
 	}
+
 	p.decodeFlags(buf[0])
 	p.ProtocolID = buf[1]
+	if p.ProtocolID != 1 {
+		return fmt.Errorf("bad CONNECT ProtocolId: expected 1, got %d", buf[1])
+	}
 	p.Duration = binary.BigEndian.Uint16(buf[2:4])
 	p.ClientID = buf[connectHeaderLength:]
 

--- a/packets1/connect_test.go
+++ b/packets1/connect_test.go
@@ -1,31 +1,72 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestConnect(t *testing.T) {
+func TestConnectConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	clientID := []byte("client-id")
 	cleanSession := true
 	will := true
 	duration := uint16(90)
 	pkt := NewConnect(duration, clientID, will, cleanSession)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Connect", reflect.TypeOf(pkt).String(), "Type should be Connect")
-		assert.Equal(t, will, pkt.Will, "Bad Will value")
-		assert.Equal(t, cleanSession, pkt.CleanSession, "Bad CleanSession value")
-		assert.Equal(t, uint8(1), pkt.ProtocolID, "Default ProtocolID should be 1")
-		assert.Equal(t, duration, pkt.Duration, "Bad Duration value")
-		assert.Equal(t, clientID, pkt.ClientID, "Bad ClientID value")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Connect", reflect.TypeOf(pkt).String(), "Type should be Connect")
+	assert.Equal(will, pkt.Will, "Bad Will value")
+	assert.Equal(cleanSession, pkt.CleanSession, "Bad CleanSession value")
+	assert.Equal(duration, pkt.Duration, "Bad Duration value")
+	assert.Equal(clientID, pkt.ClientID, "Bad ClientID value")
 }
 
 func TestConnectMarshal(t *testing.T) {
 	pkt1 := NewConnect(75, []byte("test-client"), true, true)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Connect))
+}
+
+func TestConnectUnmarshalInvalid(t *testing.T) {
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		6,                  // Length
+		byte(pkts.CONNECT), // MsgType
+		0,                  // Flags
+		1,                  // ProtocolId
+		0, 0,               // Duration
+		// ClientId missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad CONNECT packet length")
+	}
+
+	// Invalid protocol version.
+	buff = bytes.NewBuffer([]byte{
+		6,                  // Length
+		byte(pkts.CONNECT), // MsgType
+		0,                  // Flags
+		2,                  // ProtocolId
+		0, 0,               // Duration
+		byte('a'), // ClientId
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad CONNECT ProtocolId")
+	}
+}
+
+func TestConnectStringer(t *testing.T) {
+	pkt := NewConnect(123, []byte("client-id"), true, true)
+	assert.Equal(t, "CONNECT(ClientID=\"client-id\", CleanSession=true, Will=true, Duration=123)", pkt.String())
 }


### PR DESCRIPTION
This PR makes `packets1.Connect` code fully covered by unit tests. Two minor code fixes are also added because I don't think they deserve their own PRs.

The first commit adds a protocol version check to `Connect.Unpack()` - if the version is not 1, we should not parse the packet at all because we would get garbage data.

