### PR TITLE
packets1: Add full-coverage `Advertise`, `Auth`, `Connack` unit tests 

### DIFF
--- a/packets1/advertise_test.go
+++ b/packets1/advertise_test.go
@@ -1,27 +1,69 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestAdvertiseStruct(t *testing.T) {
+func TestAdvertiseConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	gatewayID := uint8(12)
 	duration := uint16(123)
 	pkt := NewAdvertise(gatewayID, duration)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Advertise", reflect.TypeOf(pkt).String(), "Type should be Advertise")
-		assert.Equal(t, gatewayID, pkt.GatewayID, "Bad GatewayID")
-		assert.Equal(t, duration, pkt.Duration, "Bad Duration value")
-		assert.Equal(t, uint16(5), pkt.PacketLength(), "Length should be 5")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Advertise", reflect.TypeOf(pkt).String(), "Type should be Advertise")
+	assert.Equal(gatewayID, pkt.GatewayID, "Bad GatewayID")
+	assert.Equal(duration, pkt.Duration, "Bad Duration value")
+	assert.Equal(uint16(5), pkt.PacketLength(), "Length should be 5")
 }
 
 func TestAdvertiseMarshal(t *testing.T) {
 	pkt1 := NewAdvertise(12, 123)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Advertise))
+}
+
+func TestAdvertiseUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		4,                    // Length
+		byte(pkts.ADVERTISE), // MsgType
+		0,                    // GwId
+		0,                    // Duration - MSB
+		// Duration - LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad ADVERTISE packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		6,                    // Length
+		byte(pkts.ADVERTISE), // MsgType
+		0,                    // GwId
+		0, 0,                 // Duration
+		0, // junk byte
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad ADVERTISE packet length")
+	}
+}
+
+func TestAdvertiseStringer(t *testing.T) {
+	pkt := NewAdvertise(12, 123)
+	assert.Equal(t, "ADVERTISE(GatewayID=12,Duration=123)", pkt.String())
 }

--- a/packets1/auth.go
+++ b/packets1/auth.go
@@ -41,10 +41,10 @@ func NewAuthPlain(user string, password []byte) *Auth {
 	p := &Auth{Header: *pkts.NewHeader(pkts.AUTH, 0)}
 	p.Method = "PLAIN"
 	var b bytes.Buffer
-	b.Write([]byte{0})
-	b.Write([]byte(user))
-	b.Write([]byte{0})
-	b.Write(password)
+	_ = b.WriteByte(0)
+	_, _ = b.Write([]byte(user))
+	_ = b.WriteByte(0)
+	_, _ = b.Write(password)
 	p.Data = b.Bytes()
 	p.computeLength()
 	return p

--- a/packets1/auth_test.go
+++ b/packets1/auth_test.go
@@ -1,13 +1,117 @@
 package packets1
 
 import (
+	"bytes"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestAuthMarshal(t *testing.T) {
+func TestAuthPlainConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	user := "test-user"
+	password := []byte("test-password")
+	pkt := NewAuthPlain(user, password)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets1.Auth", reflect.TypeOf(pkt).String(), "Type should be Auth")
+	assert.Equal(uint8(0), pkt.Reason, "Bad Reason value")
+	assert.Equal("PLAIN", pkt.Method, "Bad Method value")
+	assert.Equal(
+		[]byte(fmt.Sprintf("\x00%s\x00%s", user, password)),
+		pkt.Data, "Bad Data value")
+}
+
+func TestAuthPlainMarshal(t *testing.T) {
 	pkt1 := NewAuthPlain("test-user", []byte("test-password"))
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Auth))
+}
+
+func TestAuthUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short - Method Length missing.
+	buff := bytes.NewBuffer([]byte{
+		3,               // Length
+		byte(pkts.AUTH), // MsgType
+		0,               // Reason
+		// Method Length missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad AUTH packet length")
+	}
+
+	// Packet too short - Method missing.
+	buff = bytes.NewBuffer([]byte{
+		4,               // Length
+		byte(pkts.AUTH), // MsgType
+		0,               // Reason
+		1,               // Method Length
+		// Method missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad AUTH packet length")
+	}
+}
+
+func TestAuthDecodePlain(t *testing.T) {
+	assert := assert.New(t)
+
+	user := "test-user"
+	password := []byte("test-password")
+
+	// Correct PLAIN data.
+	buff := bytes.NewBuffer([]byte{
+		11 + byte(len(user)+len(password)), // Length
+		byte(pkts.AUTH),                    // MsgType
+		0,                                  // Reason
+		5,                                  // Method Length
+		'P', 'L', 'A', 'I', 'N',            // Method
+	})
+	// Data
+	buff.WriteByte(0)
+	buff.Write([]byte(user))
+	buff.WriteByte(0)
+	buff.Write(password)
+
+	pkt, err := ReadPacket(buff)
+	assert.Nil(err)
+
+	user2, password2, err := pkt.(*Auth).DecodePlain()
+	assert.Nil(err)
+	assert.Equal(user, user2)
+	assert.Equal(password, password2)
+
+	// Invalid PLAIN data.
+	buff = bytes.NewBuffer([]byte{
+		11,                      // Length
+		byte(pkts.AUTH),         // MsgType
+		0,                       // Reason
+		5,                       // Method Length
+		'P', 'L', 'A', 'I', 'N', // Method
+		0, 1, // Data (do not contain two zero bytes)
+	})
+	pkt, err = ReadPacket(buff)
+	assert.Nil(err)
+
+	_, _, err = pkt.(*Auth).DecodePlain()
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "invalid PLAIN auth data format")
+	}
+}
+
+func TestAuthStringer(t *testing.T) {
+	pkt := NewAuthPlain("test-user", []byte("test-password"))
+	assert.Equal(t, "AUTH(Reason=0, Method=\"PLAIN\")", pkt.String())
 }

--- a/packets1/connack_test.go
+++ b/packets1/connack_test.go
@@ -1,24 +1,64 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestConnackStruct(t *testing.T) {
-	pkt := NewConnack(RC_ACCEPTED)
+func TestConnackConstructor(t *testing.T) {
+	assert := assert.New(t)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Connack", reflect.TypeOf(pkt).String(), "Type should be Connack")
-		assert.Equal(t, RC_ACCEPTED, pkt.ReturnCode, "ReturnCode should be RC_ACCEPTED")
-		assert.Equal(t, uint16(3), pkt.PacketLength(), "Length should be 3")
+	returnCode := RC_CONGESTION
+	pkt := NewConnack(returnCode)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Connack", reflect.TypeOf(pkt).String(), "Type should be Connack")
+	assert.Equal(returnCode, pkt.ReturnCode, "invalid ReturnCode")
+	assert.Equal(uint16(3), pkt.PacketLength(), "Length should be 3")
 }
 
 func TestConnackMarshal(t *testing.T) {
 	pkt1 := NewConnack(RC_CONGESTION)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Connack))
+}
+
+func TestConnackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		2,                  // Length
+		byte(pkts.CONNACK), // MsgType
+		// Return Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad CONNACK packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		4,                  // Length
+		byte(pkts.CONNACK), // MsgType
+		0,                  // Return Code
+		0,                  // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad CONNACK packet length")
+	}
+}
+
+func TestConnackStringer(t *testing.T) {
+	pkt := NewConnack(RC_CONGESTION)
+	assert.Equal(t, "CONNACK(ReturnCode=1)", pkt.String())
 }


### PR DESCRIPTION
This PR makes `packets1.{Advertise,Auth,Connack}` code fully covered by unit tests. The second commit contains a small fix not deserving its own PR.