### PR TITLE
packets1: Add full-coverage `Disconnect`, `GwInfo`, `Ping*` unit tests

### DIFF
--- a/packets1/disconnect_test.go
+++ b/packets1/disconnect_test.go
@@ -1,24 +1,87 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestDisconnectStruct(t *testing.T) {
+func TestDisconnectConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	duration := uint16(123)
 	pkt := NewDisconnect(duration)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Disconnect", reflect.TypeOf(pkt).String(), "Type should be Disconnect")
-		assert.Equal(t, duration, pkt.Duration, "Bad Duration value")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Disconnect", reflect.TypeOf(pkt).String(), "Type should be Disconnect")
+	assert.Equal(duration, pkt.Duration, "Bad Duration value")
 }
 
 func TestDisconnectMarshal(t *testing.T) {
 	pkt1 := NewDisconnect(75)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Disconnect))
+}
+
+func TestDisconnectUnmarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet without Duration is correct (length=2).
+	buff := bytes.NewBuffer([]byte{
+		2,                     // Length
+		byte(pkts.DISCONNECT), // MsgType
+	})
+	_, err := ReadPacket(buff)
+	assert.Nil(err)
+
+	// Packet too short (length=3).
+	buff = bytes.NewBuffer([]byte{
+		3,                     // Length
+		byte(pkts.DISCONNECT), // MsgType
+		0,                     // Duration MSB
+		// Duration LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad DISCONNECT packet length")
+	}
+
+	// Packet with Duration is correct (length=4).
+	buff = bytes.NewBuffer([]byte{
+		4,                     // Length
+		byte(pkts.DISCONNECT), // MsgType
+		0, 1,                  // Duration
+	})
+	_, err = ReadPacket(buff)
+	assert.Nil(err)
+
+	// Packet too long (length=5).
+	buff = bytes.NewBuffer([]byte{
+		5,                     // Length
+		byte(pkts.DISCONNECT), // MsgType
+		0,                     // Duration MSB
+		1,                     // Duration LSB
+		0,                     // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad DISCONNECT packet length")
+	}
+}
+
+func TestDisconnectStringer(t *testing.T) {
+	// Packet without Duration.
+	pkt := NewDisconnect(0)
+	assert.Equal(t, "DISCONNECT(Duration=0)", pkt.String())
+
+	// Packet with Duration.
+	pkt = NewDisconnect(1234)
+	assert.Equal(t, "DISCONNECT(Duration=1234)", pkt.String())
 }

--- a/packets1/gwinfo_test.go
+++ b/packets1/gwinfo_test.go
@@ -1,26 +1,51 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestGwInfoStruct(t *testing.T) {
+func TestGwInfoConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	gatewayID := uint8(123)
 	gatewayAddress := []byte("test-gw")
 	pkt := NewGwInfo(gatewayID, gatewayAddress)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.GwInfo", reflect.TypeOf(pkt).String(), "Type should be GwInfo")
-		assert.Equal(t, gatewayID, pkt.GatewayID, "Bad GatewayID value")
-		assert.Equal(t, gatewayAddress, pkt.GatewayAddress, "Bad GatewayAddress value")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.GwInfo", reflect.TypeOf(pkt).String(), "Type should be GwInfo")
+	assert.Equal(gatewayID, pkt.GatewayID, "Bad GatewayID value")
+	assert.Equal(gatewayAddress, pkt.GatewayAddress, "Bad GatewayAddress value")
 }
 
 func TestGwInfoMarshal(t *testing.T) {
 	pkt1 := NewGwInfo(123, []byte("gateway-address"))
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*GwInfo))
+}
+
+func TestGwInfoUnmarshalInvalid(t *testing.T) {
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		2,                 // Length
+		byte(pkts.GWINFO), // MsgType
+		// Gateway ID missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad GWINFO packet length")
+	}
+}
+
+func TestGwInfoStringer(t *testing.T) {
+	pkt := NewGwInfo(123, []byte("gateway-address"))
+	assert.Equal(t, `GWINFO(GatewayID=123,GatewayAddress="gateway-address")`, pkt.String())
 }

--- a/packets1/pingreq_test.go
+++ b/packets1/pingreq_test.go
@@ -7,18 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPingreqStruct(t *testing.T) {
+func TestPingreqConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	clientID := []byte("test-client")
 	pkt := NewPingreq(clientID)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Pingreq", reflect.TypeOf(pkt).String(), "Type should be Pingreq")
-		assert.Equal(t, clientID, pkt.ClientID, "Bad ClientID value")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Pingreq", reflect.TypeOf(pkt).String(), "Type should be Pingreq")
+	assert.Equal(clientID, pkt.ClientID, "Bad ClientID value")
 }
 
 func TestPingreqMarshal(t *testing.T) {
 	pkt1 := NewPingreq([]byte("test-client"))
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Pingreq))
+}
+
+func TestPingreqStringer(t *testing.T) {
+	pkt := NewPingreq([]byte("test-client"))
+	assert.Equal(t, `PINGREQ(ClientID="test-client")`, pkt.String())
 }

--- a/packets1/pingresp_test.go
+++ b/packets1/pingresp_test.go
@@ -7,17 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPingrespStruct(t *testing.T) {
+func TestPingrespConstructor(t *testing.T) {
 	pkt := NewPingresp()
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Pingresp", reflect.TypeOf(pkt).String(), "Type should be Pingresp")
-		assert.Equal(t, uint16(2), pkt.PacketLength(), "Default Length should be 2")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal(t, "*packets1.Pingresp", reflect.TypeOf(pkt).String(), "Type should be Pingresp")
+	assert.Equal(t, uint16(2), pkt.PacketLength(), "Default Length should be 2")
 }
 
 func TestPingrespMarshal(t *testing.T) {
 	pkt1 := NewPingresp()
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Pingresp))
+}
+
+func TestPingrespStringer(t *testing.T) {
+	pkt := NewPingresp()
+	assert.Equal(t, "PINGRESP", pkt.String())
 }


### PR DESCRIPTION
This PR makes packets1.{Disconnect,GwInfo,Ping*} code fully covered by unit tests.