### PR TITLE
packets1: Add full-coverage unit tests for publish-related packets

### DIFF
--- a/packets1/puback_test.go
+++ b/packets1/puback_test.go
@@ -1,24 +1,31 @@
 package packets1
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestPubackStruct(t *testing.T) {
+func TestPubackConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	topicID := uint16(123)
 	pkt := NewPuback(topicID, RC_ACCEPTED)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Puback", reflect.TypeOf(pkt).String(), "Type should be Puback")
-		assert.Equal(t, topicID, pkt.TopicID, fmt.Sprintf("TopicID should be %d", topicID))
-		assert.Equal(t, uint16(0), pkt.MessageID(), "Default MessageID should be 0")
-		assert.Equal(t, RC_ACCEPTED, pkt.ReturnCode, "ReturnCode should be RC_ACCEPTED")
-		assert.Equal(t, uint16(7), pkt.PacketLength(), "Default Length should be 2")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Puback", reflect.TypeOf(pkt).String(), "Type should be Puback")
+	assert.Equal(topicID, pkt.TopicID, fmt.Sprintf("TopicID should be %d", topicID))
+	assert.Equal(uint16(0), pkt.MessageID(), "Default MessageID should be 0")
+	assert.Equal(RC_ACCEPTED, pkt.ReturnCode, "ReturnCode should be RC_ACCEPTED")
+	assert.Equal(uint16(7), pkt.PacketLength(), "Default Length should be 2")
 }
 
 func TestPubackMarshal(t *testing.T) {
@@ -26,4 +33,41 @@ func TestPubackMarshal(t *testing.T) {
 	pkt1.SetMessageID(12)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Puback))
+}
+
+func TestPubackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		6,                 // Length
+		byte(pkts.PUBACK), // MsgType
+		0, 1,              // Topic ID
+		0, 2, // Message ID
+		// Return Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBACK packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		6,                 // Length
+		byte(pkts.PUBACK), // MsgType
+		0, 1,              // Topic ID
+		0, 2, // Message ID
+		3, // Return Code
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBACK packet length")
+	}
+}
+
+func TestPubackStringer(t *testing.T) {
+	pkt := NewPuback(123, RC_CONGESTION)
+	pkt.SetMessageID(12)
+	assert.Equal(t, "PUBACK(TopicID=123, ReturnCode=1, MessageID=12)", pkt.String())
 }

--- a/packets1/pubcomp_test.go
+++ b/packets1/pubcomp_test.go
@@ -1,24 +1,66 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestPubcompStruct(t *testing.T) {
+func TestPubcompConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	pkt := NewPubcomp()
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Pubcomp", reflect.TypeOf(pkt).String(), "Type should be Pubcomp")
-		assert.Equal(t, uint16(4), pkt.PacketLength(), "Default Length should be 4")
-		assert.Equal(t, uint16(0), pkt.MessageID(), "Default MessageID should be 0")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Pubcomp", reflect.TypeOf(pkt).String(), "Type should be Pubcomp")
+	assert.Equal(uint16(4), pkt.PacketLength(), "Default Length should be 4")
+	assert.Equal(uint16(0), pkt.MessageID(), "Default MessageID should be 0")
 }
 
 func TestPubcompMarshal(t *testing.T) {
 	pkt1 := NewPubcomp()
+	pkt1.SetMessageID(1234)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Pubcomp))
+}
+
+func TestPubcompUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                  // Length
+		byte(pkts.PUBCOMP), // MsgType
+		0,                  // Message ID MSB
+		// Message ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBCOMP packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                  // Length
+		byte(pkts.PUBCOMP), // MsgType
+		0, 1,               // Message ID
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBCOMP packet length")
+	}
+}
+
+func TestPubcompStringer(t *testing.T) {
+	pkt := NewPubcomp()
+	pkt.SetMessageID(1234)
+	assert.Equal(t, "PUBCOMP(MessageID=1234)", pkt.String())
 }

--- a/packets1/publish.go
+++ b/packets1/publish.go
@@ -23,7 +23,7 @@ type Publish struct {
 }
 
 // NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
-func NewPublish(topicID uint16, payload []byte, dup bool, qos uint8, retain bool,
+func NewPublish(topicID uint16, data []byte, dup bool, qos uint8, retain bool,
 	topicIDType uint8) *Publish {
 	p := &Publish{
 		Header:      *pkts.NewHeader(pkts.PUBLISH, 0),
@@ -32,15 +32,15 @@ func NewPublish(topicID uint16, payload []byte, dup bool, qos uint8, retain bool
 		Retain:      retain,
 		TopicIDType: topicIDType,
 		TopicID:     topicID,
-		Data:        payload,
+		Data:        data,
 	}
 	p.computeLength()
 	return p
 }
 
 func (p *Publish) computeLength() {
-	payloadLen := uint16(len(p.Data))
-	p.Header.SetVarPartLength(publishHeaderLength + payloadLen)
+	dataLen := uint16(len(p.Data))
+	p.Header.SetVarPartLength(publishHeaderLength + dataLen)
 }
 
 func (p *Publish) encodeFlags() byte {

--- a/packets1/publish_test.go
+++ b/packets1/publish_test.go
@@ -1,36 +1,81 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestPublishStruct(t *testing.T) {
-	dup := true
-	retain := true
-	qos := uint8(1)
-	topicIDType := TIT_SHORT
-	topicID := uint16(123)
-	payload := []byte("test-payload")
-	pkt := NewPublish(topicID, payload, dup, qos, retain, topicIDType)
+func TestPublishConstructor(t *testing.T) {
+	assert := assert.New(t)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Publish", reflect.TypeOf(pkt).String(), "Type should be Publish")
-		assert.Equal(t, dup, pkt.DUP(), "Bad Dup flag value")
-		assert.Equal(t, retain, pkt.Retain, "Bad Retain flag value")
-		assert.Equal(t, qos, pkt.QOS, "Bad QOS value")
-		assert.Equal(t, topicIDType, pkt.TopicIDType, "Bad TopicIDType value")
-		assert.Equal(t, topicID, pkt.TopicID, "Bad TopicID value")
-		assert.Equal(t, uint16(0), pkt.MessageID(), "Default MessageID should be 0")
-		assert.Equal(t, payload, pkt.Data, "Bad Data value")
+	dup := true
+	qos := uint8(1)
+	retain := true
+	topicIDType := TIT_SHORT
+	topicID := uint16(1234)
+	data := []byte("test-data")
+	pkt := NewPublish(topicID, data, dup, qos, retain, topicIDType)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Publish", reflect.TypeOf(pkt).String(), "Type should be Publish")
+	assert.Equal(dup, pkt.DUP(), "Bad Dup flag value")
+	assert.Equal(retain, pkt.Retain, "Bad Retain flag value")
+	assert.Equal(qos, pkt.QOS, "Bad QOS value")
+	assert.Equal(topicIDType, pkt.TopicIDType, "Bad TopicIDType value")
+	assert.Equal(topicID, pkt.TopicID, "Bad TopicID value")
+	assert.Equal(uint16(0), pkt.MessageID(), "Default MessageID should be 0")
+	assert.Equal(data, pkt.Data, "Bad Data value")
 }
 
 func TestPublishMarshal(t *testing.T) {
-	pkt1 := NewPublish(123, []byte("test-payload"), true, 1, true, TIT_PREDEFINED)
-	pkt1.SetMessageID(12)
+	pkt1 := NewPublish(1234, []byte("test-data"), true, 1, true, TIT_PREDEFINED)
+	pkt1.SetMessageID(2345)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Publish))
+}
+
+func TestPublishUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                  // Length
+		byte(pkts.PUBLISH), // MsgType
+		0,                  // Flags
+		0, 1,               // Topic ID
+		0, // Message ID MSB
+		// Message ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH packet length")
+	}
+}
+
+func TestPublishStringer(t *testing.T) {
+	pkt := NewPublish(1234, []byte("test-data"), true, 1, true, TIT_REGISTERED)
+	pkt.SetMessageID(2345)
+	assert.Equal(t,
+		`PUBLISH(TopicID(r)=1234, Data="test-data", QOS=1, Retain=true, MessageID=2345, Dup=true)`,
+		pkt.String())
+
+	pkt = NewPublish(1234, []byte("test-data"), true, 1, true, TIT_PREDEFINED)
+	pkt.SetMessageID(2345)
+	assert.Equal(t,
+		`PUBLISH(TopicID(p)=1234, Data="test-data", QOS=1, Retain=true, MessageID=2345, Dup=true)`,
+		pkt.String())
+
+	pkt = NewPublish(1234, []byte("test-data"), true, 1, true, TIT_SHORT)
+	pkt.SetMessageID(2345)
+	assert.Equal(t,
+		`PUBLISH(TopicID(s)=1234, Data="test-data", QOS=1, Retain=true, MessageID=2345, Dup=true)`,
+		pkt.String())
 }

--- a/packets1/pubrec_test.go
+++ b/packets1/pubrec_test.go
@@ -1,25 +1,66 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestPubrecStruct(t *testing.T) {
+func TestPubrecConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	pkt := NewPubrec()
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Pubrec", reflect.TypeOf(pkt).String(), "Type should be Pubrec")
-		assert.Equal(t, uint16(4), pkt.PacketLength(), "Default Length should be 4")
-		assert.Equal(t, uint16(0), pkt.MessageID(), "Default MessageID should be 0")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Pubrec", reflect.TypeOf(pkt).String(), "Type should be Pubrec")
+	assert.Equal(uint16(4), pkt.PacketLength(), "Default Length should be 4")
+	assert.Equal(uint16(0), pkt.MessageID(), "Default MessageID should be 0")
 }
 
 func TestPubrecMarshal(t *testing.T) {
 	pkt1 := NewPubrec()
-	pkt1.SetMessageID(12)
+	pkt1.SetMessageID(1234)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Pubrec))
+}
+
+func TestPubrecUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                 // Length
+		byte(pkts.PUBREC), // MsgType
+		0,                 // Message ID MSB
+		// Message ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREC packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                 // Length
+		byte(pkts.PUBREC), // MsgType
+		0, 1,              // Message ID
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREC packet length")
+	}
+}
+
+func TestPubrecStringer(t *testing.T) {
+	pkt := NewPubrec()
+	pkt.SetMessageID(1234)
+	assert.Equal(t, "PUBREC(MessageID=1234)", pkt.String())
 }

--- a/packets1/pubrel_test.go
+++ b/packets1/pubrel_test.go
@@ -1,25 +1,66 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestPubrelStruct(t *testing.T) {
+func TestPubrelConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	pkt := NewPubrel()
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.Pubrel", reflect.TypeOf(pkt).String(), "Type should be Pubrel")
-		assert.Equal(t, uint16(4), pkt.PacketLength(), "Default Length should be 4")
-		assert.Equal(t, uint16(0), pkt.MessageID(), "Default MessageID should be 0")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.Pubrel", reflect.TypeOf(pkt).String(), "Type should be Pubrel")
+	assert.Equal(uint16(4), pkt.PacketLength(), "Default Length should be 4")
+	assert.Equal(uint16(0), pkt.MessageID(), "Default MessageID should be 0")
 }
 
 func TestPubrelMarshal(t *testing.T) {
 	pkt1 := NewPubrel()
-	pkt1.SetMessageID(12)
+	pkt1.SetMessageID(1234)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*Pubrel))
+}
+
+func TestPubrelUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                 // Length
+		byte(pkts.PUBREL), // MsgType
+		0,                 // Message ID MSB
+		// Message ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREL packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                 // Length
+		byte(pkts.PUBREL), // MsgType
+		0, 1,              // Message ID
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREL packet length")
+	}
+}
+
+func TestPubrelStringer(t *testing.T) {
+	pkt := NewPubrel()
+	pkt.SetMessageID(1234)
+	assert.Equal(t, "PUBREL(MessageID=1234)", pkt.String())
 }


### PR DESCRIPTION
The first commit is a small aesthetic fix. The other commits make `packets1.{Pub*}` code fully covered by unit tests.