### PR TITLE
packets1: Fix `WILLTOPICUPD` implementation

### DIFF
--- a/packets1/willtopicupd_test.go
+++ b/packets1/willtopicupd_test.go
@@ -1,29 +1,65 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestWillTopicUpdStruct(t *testing.T) {
-	willTopic := "test-topic"
+func TestWillTopicUpdConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	qos := uint8(1)
-	retain := true
+	retain := false
+	willTopic := "test-topic"
 	pkt := NewWillTopicUpd(willTopic, qos, retain)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillTopicUpd", reflect.TypeOf(pkt).String(), "Type should be WillTopicUpd")
-		assert.Equal(t, qos, pkt.QOS, "Bad QOS value")
-		assert.Equal(t, retain, pkt.Retain, "Bad Retain flag value")
-		assert.Equal(t, willTopic, pkt.WillTopic, "Bad WillTopic value")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
 
+	assert.Equal("*packets1.WillTopicUpd", reflect.TypeOf(pkt).String(), "Type should be WillTopicUpd")
+	assert.Equal(qos, pkt.QOS, "Bad QOS value")
+	assert.Equal(retain, pkt.Retain, "Bad Retain flag value")
+	assert.Equal(willTopic, pkt.WillTopic, "Bad WillTopicUpd value")
 }
 
 func TestWillTopicUpdMarshal(t *testing.T) {
 	pkt1 := NewWillTopicUpd("test-topic", 1, true)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillTopicUpd))
+
+	// Packet with a zero-length topic is a special case (does not contain Flags).
+	pkt1 = NewWillTopicUpd("", 0, false)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillTopicUpd))
+}
+
+func TestWillTopicUpdUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                       // Length
+		byte(pkts.WILLTOPICUPD), // MsgType
+		0,                       // Flags
+		// Will Topic missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLTOPICUPD packet length")
+	}
+}
+
+func TestWillTopicUpdStringer(t *testing.T) {
+	pkt := NewWillTopicUpd("test-topic", 1, true)
+	assert.Equal(t, `WILLTOPICUPD(WillTopicUpd="test-topic", QOS=1, Retain=true)`, pkt.String())
+
+	// Packet with a zero-length topic.
+	pkt = NewWillTopicUpd("", 0, false)
+	assert.Equal(t, `WILLTOPICUPD(WillTopicUpd="")`, pkt.String())
 }


### PR DESCRIPTION
Like in `WILLTOPIC`, the `WILLTOPICUPD` packet must not contain `Flags` if `WillMsg` length is zero.

The old implementation inserts `Flags` field into the packet regardless of `WillMsg`. This PR introduces the right behavior and improved `WillTopicUpd` tests.