### PR TITLE
packets1: Add full-coverage `Will*` and `MessageIDProperty` unit tests

### DIFF
--- a/packets1/property_message_id_test.go
+++ b/packets1/property_message_id_test.go
@@ -1,0 +1,19 @@
+package packets1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMessageID(t *testing.T) {
+	msgID := uint16(1234)
+
+	pkt1 := NewPubrec()
+	pkt1.SetMessageID(msgID)
+	assert.Equal(t, msgID, pkt1.MessageID())
+
+	pkt2 := NewPubrel()
+	pkt2.CopyMessageID(pkt1)
+	assert.Equal(t, msgID, pkt2.MessageID())
+}

--- a/packets1/willmsg_test.go
+++ b/packets1/willmsg_test.go
@@ -7,18 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWillMsgStruct(t *testing.T) {
-	payload := []byte("test-payload")
-	pkt := NewWillMsg(payload)
+func TestWillMsgConstructor(t *testing.T) {
+	assert := assert.New(t)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillMsg", reflect.TypeOf(pkt).String(), "Type should be WillMsg")
-		assert.Equal(t, payload, pkt.WillMsg, "Bad WillMsg value")
+	data := []byte("test-data")
+	pkt := NewWillMsg(data)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.WillMsg", reflect.TypeOf(pkt).String(), "Type should be WillMsg")
+	assert.Equal(data, pkt.WillMsg, "Bad WillMsg value")
 }
 
 func TestWillMsgMarshal(t *testing.T) {
 	pkt1 := NewWillMsg([]byte("test-message"))
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillMsg))
+}
+
+func TestWillMsgStringer(t *testing.T) {
+	pkt := NewWillMsg([]byte("test-data"))
+	assert.Equal(t, `WILLMSG(WillMsg="test-data")`, pkt.String())
 }

--- a/packets1/willmsgreq_test.go
+++ b/packets1/willmsgreq_test.go
@@ -1,22 +1,47 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestWillMsgReqStruct(t *testing.T) {
+func TestWillMsgReqConstructor(t *testing.T) {
 	pkt := NewWillMsgReq()
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillMsgReq", reflect.TypeOf(pkt).String(), "Type should be WillMsgReq")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal(t, "*packets1.WillMsgReq", reflect.TypeOf(pkt).String(), "Type should be WillMsgReq")
 }
 
 func TestWillMsgReqMarshal(t *testing.T) {
 	pkt1 := NewWillMsgReq()
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillMsgReq))
+}
+
+func TestWillMsgReqUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too long.
+	buff := bytes.NewBuffer([]byte{
+		3,                     // Length
+		byte(pkts.WILLMSGREQ), // MsgType
+		0,                     // junk
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLMSGREQ packet length")
+	}
+}
+
+func TestWillMsgReqStringer(t *testing.T) {
+	pkt := NewWillMsgReq()
+	assert.Equal(t, "WILLMSGREQ", pkt.String())
 }

--- a/packets1/willmsgresp_test.go
+++ b/packets1/willmsgresp_test.go
@@ -1,23 +1,62 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestWillMsgRespStruct(t *testing.T) {
-	pkt := NewWillMsgResp(RC_ACCEPTED)
+func TestWillMsgRespConstructor(t *testing.T) {
+	assert := assert.New(t)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillMsgResp", reflect.TypeOf(pkt).String(), "Type should be WillMsgResp")
-		assert.Equal(t, RC_ACCEPTED, pkt.ReturnCode, "Default ReturnCode should be RC_ACCEPTED")
+	pkt := NewWillMsgResp(RC_CONGESTION)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.WillMsgResp", reflect.TypeOf(pkt).String(), "Type should be WillMsgResp")
+	assert.Equal(RC_CONGESTION, pkt.ReturnCode, "ReturnCode should be RC_CONGESTION")
 }
 
 func TestWillMsgRespMarshal(t *testing.T) {
 	pkt1 := NewWillMsgResp(RC_CONGESTION)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillMsgResp))
+}
+
+func TestWillMsgRespUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		2,                      // Length
+		byte(pkts.WILLMSGRESP), // MsgType
+		// Return Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLMSGRESP packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		4,                      // Length
+		byte(pkts.WILLMSGRESP), // MsgType
+		0,                      // Return Code
+		0,                      // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLMSGRESP packet length")
+	}
+}
+
+func TestWillMsgRespStringer(t *testing.T) {
+	pkt := NewWillMsgResp(RC_CONGESTION)
+	assert.Equal(t, "WILLMSGRESP(ReturnCode=1)", pkt.String())
 }

--- a/packets1/willmsgupd_test.go
+++ b/packets1/willmsgupd_test.go
@@ -7,18 +7,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWillMsgUpdStruct(t *testing.T) {
-	willMsg := []byte("test-msg")
-	pkt := NewWillMsgUpd(willMsg)
+func TestWillMsgUpdConstructor(t *testing.T) {
+	assert := assert.New(t)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillMsgUpd", reflect.TypeOf(pkt).String(), "Type should be WillMsgUpd")
-		assert.Equal(t, willMsg, pkt.WillMsg, "Bad WillMsg value")
+	data := []byte("test-data")
+	pkt := NewWillMsgUpd(data)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.WillMsgUpd", reflect.TypeOf(pkt).String(), "Type should be WillMsgUpd")
+	assert.Equal(data, pkt.WillMsg, "Bad WillMsg value")
 }
 
 func TestWillMsgUpdMarshal(t *testing.T) {
 	pkt1 := NewWillMsgUpd([]byte("test-message"))
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillMsgUpd))
+}
+
+func TestWillMsgUpdStringer(t *testing.T) {
+	pkt := NewWillMsgUpd([]byte("test-data"))
+	assert.Equal(t, `WILLMSGUPD(WillMsg="test-data")`, pkt.String())
 }

--- a/packets1/willtopic.go
+++ b/packets1/willtopic.go
@@ -84,5 +84,8 @@ func (p *WillTopic) Unpack(buf []byte) error {
 }
 
 func (p WillTopic) String() string {
+	if len(p.WillTopic) == 0 {
+		return fmt.Sprintf(`WILLTOPIC(WillTopic="")`)
+	}
 	return fmt.Sprintf("WILLTOPIC(WillTopic=%#v, QOS=%d, Retain=%t)", p.WillTopic, p.QOS, p.Retain)
 }

--- a/packets1/willtopic_test.go
+++ b/packets1/willtopic_test.go
@@ -1,28 +1,65 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestWillTopicStruct(t *testing.T) {
+func TestWillTopicConstructor(t *testing.T) {
+	assert := assert.New(t)
+
 	qos := uint8(1)
 	retain := false
 	willTopic := "test-topic"
 	pkt := NewWillTopic(willTopic, qos, retain)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillTopic", reflect.TypeOf(pkt).String(), "Type should be WillTopic")
-		assert.Equal(t, qos, pkt.QOS, "Bad QOS value")
-		assert.Equal(t, retain, pkt.Retain, "Bad Retain flag value")
-		assert.Equal(t, willTopic, pkt.WillTopic, "Bad WillTopic value")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.WillTopic", reflect.TypeOf(pkt).String(), "Type should be WillTopic")
+	assert.Equal(qos, pkt.QOS, "Bad QOS value")
+	assert.Equal(retain, pkt.Retain, "Bad Retain flag value")
+	assert.Equal(willTopic, pkt.WillTopic, "Bad WillTopic value")
 }
 
 func TestWillTopicMarshal(t *testing.T) {
 	pkt1 := NewWillTopic("test-topic", 1, true)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillTopic))
+
+	// Packet with zero-length topic is a special case (does not contain Flags).
+	pkt1 = NewWillTopic("", 0, false)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*WillTopic))
+}
+
+func TestWillTopicUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                    // Length
+		byte(pkts.WILLTOPIC), // MsgType
+		0,                    // Flags
+		// Will Topic missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLTOPIC packet length")
+	}
+}
+
+func TestWillTopicStringer(t *testing.T) {
+	pkt := NewWillTopic("test-topic", 1, true)
+	assert.Equal(t, `WILLTOPIC(WillTopic="test-topic", QOS=1, Retain=true)`, pkt.String())
+
+	// Packet with zero-length topic.
+	pkt = NewWillTopic("", 0, false)
+	assert.Equal(t, `WILLTOPIC(WillTopic="")`, pkt.String())
 }

--- a/packets1/willtopicreq_test.go
+++ b/packets1/willtopicreq_test.go
@@ -1,22 +1,47 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestWillTopicReqStruct(t *testing.T) {
+func TestWillTopicReqConstructor(t *testing.T) {
 	pkt := NewWillTopicReq()
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillTopicReq", reflect.TypeOf(pkt).String(), "Type should be WillTopicReq")
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal(t, "*packets1.WillTopicReq", reflect.TypeOf(pkt).String(), "Type should be WillTopicReq")
 }
 
 func TestWillTopicReqMarshal(t *testing.T) {
 	pkt1 := NewWillTopicReq()
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillTopicReq))
+}
+
+func TestWillTopicReqUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too long.
+	buff := bytes.NewBuffer([]byte{
+		3,                       // Length
+		byte(pkts.WILLTOPICREQ), // MsgType
+		0,                       // junk
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLTOPICREQ packet length")
+	}
+}
+
+func TestWillTopicReqStringer(t *testing.T) {
+	pkt := NewWillTopicReq()
+	assert.Equal(t, "WILLTOPICREQ", pkt.String())
 }

--- a/packets1/willtopicresp_test.go
+++ b/packets1/willtopicresp_test.go
@@ -1,23 +1,62 @@
 package packets1
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
 )
 
-func TestWillTopicRespStruct(t *testing.T) {
-	pkt := NewWillTopicResp(RC_ACCEPTED)
+func TestWillTopicRespConstructor(t *testing.T) {
+	assert := assert.New(t)
 
-	if assert.NotNil(t, pkt, "New packet should not be nil") {
-		assert.Equal(t, "*packets1.WillTopicResp", reflect.TypeOf(pkt).String(), "Type should be WillTopicResp")
-		assert.Equal(t, RC_ACCEPTED, pkt.ReturnCode, "ReturnCode should be RC_ACCEPTED")
+	pkt := NewWillTopicResp(RC_CONGESTION)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
 	}
+
+	assert.Equal("*packets1.WillTopicResp", reflect.TypeOf(pkt).String(), "Type should be WillTopicResp")
+	assert.Equal(RC_CONGESTION, pkt.ReturnCode, "ReturnCode should be RC_CONGESTION")
 }
 
 func TestWillTopicRespMarshal(t *testing.T) {
 	pkt1 := NewWillTopicResp(RC_CONGESTION)
 	pkt2 := testPacketMarshal(t, pkt1)
 	assert.Equal(t, pkt1, pkt2.(*WillTopicResp))
+}
+
+func TestWillTopicRespUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		2,                        // Length
+		byte(pkts.WILLTOPICRESP), // MsgType
+		// Return Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLTOPICRESP packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		4,                        // Length
+		byte(pkts.WILLTOPICRESP), // MsgType
+		0,                        // Return Code
+		0,                        // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad WILLTOPICRESP packet length")
+	}
+}
+
+func TestWillTopicRespStringer(t *testing.T) {
+	pkt := NewWillTopicResp(RC_CONGESTION)
+	assert.Equal(t, "WILLTOPICRESP(ReturnCode=1)", pkt.String())
 }


### PR DESCRIPTION
The first commit improves the way `WillTopic` packets are stringified by `String()` (similar to the first commit of #51). 

The other commits make `packets1.Will*` and `MessageIDProperty` code fully covered by unit tests.