### PR TITLE
packets2: Add gateway-related packets

### DIFF
--- a/packets2/advertise.go
+++ b/packets2/advertise.go
@@ -1,0 +1,52 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const advertiseVarPartLength uint16 = 3
+
+type Advertise struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	GatewayID uint8
+	Duration  uint16
+}
+
+func NewAdvertise(gatewayID uint8, duration uint16) *Advertise {
+	return &Advertise{
+		Header:    *pkts.NewHeader(pkts.ADVERTISE, advertiseVarPartLength),
+		GatewayID: gatewayID,
+		Duration:  duration,
+	}
+}
+
+func (p *Advertise) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.GatewayID)
+	_, _ = buf.Write(pkts.EncodeUint16(p.Duration))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Advertise) Unpack(buf []byte) error {
+	if len(buf) != int(advertiseVarPartLength) {
+		return fmt.Errorf("bad ADVERTISE2 packet length: expected %d, got %d",
+			advertiseVarPartLength, len(buf))
+	}
+
+	p.GatewayID = buf[0]
+	p.Duration = binary.BigEndian.Uint16(buf[1:3])
+
+	return nil
+}
+
+func (p Advertise) String() string {
+	return fmt.Sprintf("ADVERTISE2(GatewayID=%d,Duration=%d)",
+		p.GatewayID, p.Duration)
+}

--- a/packets2/advertise_test.go
+++ b/packets2/advertise_test.go
@@ -1,0 +1,69 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestAdvertiseConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	gatewayID := uint8(12)
+	duration := uint16(123)
+	pkt := NewAdvertise(gatewayID, duration)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Advertise", reflect.TypeOf(pkt).String(), "Type should be Advertise")
+	assert.Equal(gatewayID, pkt.GatewayID, "Bad GatewayID")
+	assert.Equal(duration, pkt.Duration, "Bad Duration value")
+	assert.Equal(uint16(5), pkt.PacketLength(), "Length should be 5")
+}
+
+func TestAdvertiseMarshal(t *testing.T) {
+	pkt1 := NewAdvertise(12, 123)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Advertise))
+}
+
+func TestAdvertiseUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		4,                    // Length
+		byte(pkts.ADVERTISE), // MsgType
+		0,                    // GwId
+		0,                    // Duration - MSB
+		// Duration - LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad ADVERTISE2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		6,                    // Length
+		byte(pkts.ADVERTISE), // MsgType
+		0,                    // GwId
+		0, 0,                 // Duration
+		0, // junk byte
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad ADVERTISE2 packet length")
+	}
+}
+
+func TestAdvertiseStringer(t *testing.T) {
+	pkt := NewAdvertise(12, 123)
+	assert.Equal(t, "ADVERTISE2(GatewayID=12,Duration=123)", pkt.String())
+}

--- a/packets2/gwinfo.go
+++ b/packets2/gwinfo.go
@@ -1,0 +1,60 @@
+package packets2
+
+import (
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const gwInfoHeaderLength uint16 = 1
+
+type GwInfo struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	GatewayID      uint8
+	GatewayAddress []byte
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewGwInfo(gatewayID uint8, gatewayAddress []byte) *GwInfo {
+	p := &GwInfo{
+		Header:         *pkts.NewHeader(pkts.GWINFO, 0),
+		GatewayID:      gatewayID,
+		GatewayAddress: gatewayAddress,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *GwInfo) computeLength() {
+	addrLength := uint16(len(p.GatewayAddress))
+	p.Header.SetVarPartLength(gwInfoHeaderLength + addrLength)
+}
+
+func (p *GwInfo) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.GatewayID)
+	_, _ = buf.Write(p.GatewayAddress)
+
+	return buf.Bytes(), nil
+}
+
+func (p *GwInfo) Unpack(buf []byte) error {
+	if len(buf) < int(gwInfoHeaderLength) {
+		return fmt.Errorf("bad GWINFO2 packet length: expected >=%d, got %d",
+			gwInfoHeaderLength, len(buf))
+	}
+
+	p.GatewayID = buf[0]
+	p.GatewayAddress = buf[1:]
+
+	return nil
+}
+
+func (p GwInfo) String() string {
+	return fmt.Sprintf("GWINFO2(GatewayID=%d,GatewayAddress=%#v)",
+		p.GatewayID, string(p.GatewayAddress))
+}

--- a/packets2/gwinfo_test.go
+++ b/packets2/gwinfo_test.go
@@ -1,0 +1,51 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestGwInfoConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	gatewayID := uint8(123)
+	gatewayAddress := []byte("test-gw")
+	pkt := NewGwInfo(gatewayID, gatewayAddress)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.GwInfo", reflect.TypeOf(pkt).String(), "Type should be GwInfo")
+	assert.Equal(gatewayID, pkt.GatewayID, "Bad GatewayID value")
+	assert.Equal(gatewayAddress, pkt.GatewayAddress, "Bad GatewayAddress value")
+}
+
+func TestGwInfoMarshal(t *testing.T) {
+	pkt1 := NewGwInfo(123, []byte("gateway-address"))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*GwInfo))
+}
+
+func TestGwInfoUnmarshalInvalid(t *testing.T) {
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		2,                 // Length
+		byte(pkts.GWINFO), // MsgType
+		// Gateway ID missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad GWINFO2 packet length")
+	}
+}
+
+func TestGwInfoStringer(t *testing.T) {
+	pkt := NewGwInfo(123, []byte("gateway-address"))
+	assert.Equal(t, `GWINFO2(GatewayID=123,GatewayAddress="gateway-address")`, pkt.String())
+}

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -109,8 +109,8 @@ const flagsTopicAliasTypeBits = 0b00000011
 // The struct type is determined by h.msgType.
 func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	switch h.PacketType() {
-	//case pkts.ADVERTISE:
-	//	pkt = &Advertise{Header: h}
+	case pkts.ADVERTISE:
+		pkt = &Advertise{Header: h}
 	//case pkts.SEARCHGW:
 	//	pkt = &SearchGw{Header: h}
 	//case pkts.GWINFO:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -111,8 +111,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	switch h.PacketType() {
 	case pkts.ADVERTISE:
 		pkt = &Advertise{Header: h}
-	//case pkts.SEARCHGW:
-	//	pkt = &SearchGw{Header: h}
+	case pkts.SEARCHGW:
+		pkt = &SearchGw{Header: h}
 	case pkts.GWINFO:
 		pkt = &GwInfo{Header: h}
 	//case pkts.AUTH:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -113,8 +113,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Advertise{Header: h}
 	//case pkts.SEARCHGW:
 	//	pkt = &SearchGw{Header: h}
-	//case pkts.GWINFO:
-	//	pkt = &GwInfo{Header: h}
+	case pkts.GWINFO:
+		pkt = &GwInfo{Header: h}
 	//case pkts.AUTH:
 	//	pkt = &Auth{Header: h}
 	//case pkts.CONNECT:

--- a/packets2/searchgw.go
+++ b/packets2/searchgw.go
@@ -1,0 +1,46 @@
+package packets2
+
+import (
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const searchGwVarPartLength uint16 = 1
+
+type SearchGw struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	Radius uint8
+}
+
+func NewSearchGw(radius uint8) *SearchGw {
+	return &SearchGw{
+		Header: *pkts.NewHeader(pkts.SEARCHGW, searchGwVarPartLength),
+		Radius: radius,
+	}
+}
+
+func (p *SearchGw) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.Radius)
+
+	return buf.Bytes(), nil
+}
+
+func (p *SearchGw) Unpack(buf []byte) error {
+	if len(buf) != int(searchGwVarPartLength) {
+		return fmt.Errorf("bad SEARCHGW2 packet length: expected %d, got %d",
+			searchGwVarPartLength, len(buf))
+	}
+
+	p.Radius = buf[0]
+
+	return nil
+}
+
+func (p SearchGw) String() string {
+	return fmt.Sprintf("SEARCHGW2(Radius=%d)", p.Radius)
+}

--- a/packets2/searchgw_test.go
+++ b/packets2/searchgw_test.go
@@ -1,0 +1,64 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestSearchGwConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	radius := uint8(123)
+	pkt := NewSearchGw(radius)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.SearchGw", reflect.TypeOf(pkt).String(), "Type should be SearchGw")
+	assert.Equal(uint16(3), pkt.PacketLength(), "Default Length should be 3")
+	assert.Equal(radius, pkt.Radius, "Bad Radius value")
+}
+
+func TestSearchGwMarshal(t *testing.T) {
+	pkt1 := NewSearchGw(123)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*SearchGw))
+}
+
+func TestSearchGwUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		2,                   // Length
+		byte(pkts.SEARCHGW), // MsgType
+		// Radius missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SEARCHGW2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		4,                   // Length
+		byte(pkts.SEARCHGW), // MsgType
+		1,                   // Radius
+		0,                   // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SEARCHGW2 packet length")
+	}
+}
+
+func TestSearchGwStringer(t *testing.T) {
+	pkt := NewSearchGw(123)
+	assert.Equal(t, "SEARCHGW2(Radius=123)", pkt.String())
+}


### PR DESCRIPTION
PR adds gateway-related packets: `Advertise`, `GwInfo`, `SearchGw`.

Failed tests are OK. They will pass as long as all packets are merged in.