### PR TITLE
packets2: Add connection-related packets

### DIFF
--- a/packets2/auth.go
+++ b/packets2/auth.go
@@ -1,0 +1,94 @@
+package packets2
+
+import (
+	"bytes"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+// Auth method constants.
+const (
+	AUTH_PLAIN = "PLAIN"
+)
+
+const authHeaderLength uint16 = 2
+
+type Auth struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	ReasonCode ReasonCode
+	Method     string
+	Data       []byte
+}
+
+// NewAuthPlain creates a new Auth with "PLAIN" method encoded
+// authentication data.
+// SASL PLAIN method specification: https://datatracker.ietf.org/doc/html/rfc4616
+func NewAuthPlain(user string, password []byte) *Auth {
+	p := &Auth{Header: *pkts.NewHeader(pkts.AUTH, 0)}
+	p.Method = "PLAIN"
+	var b bytes.Buffer
+	_ = b.WriteByte(0)
+	_, _ = b.Write([]byte(user))
+	_ = b.WriteByte(0)
+	_, _ = b.Write(password)
+	p.Data = b.Bytes()
+	p.computeLength()
+	return p
+}
+
+// DecodePlain decodes username and password from AUTH package data encoded
+// using "PLAIN" method.
+func (p *Auth) DecodePlain() (string, []byte, error) {
+	dataParts := bytes.Split(p.Data, []byte{0})
+	if len(dataParts) != 3 {
+		return "", nil, fmt.Errorf("invalid PLAIN auth data format: %v.", p.Data)
+	}
+	// NOTE: PLAIN first part (authorization identity) not used.
+	return string(dataParts[1]), dataParts[2], nil
+}
+
+func (p *Auth) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(byte(p.ReasonCode))
+	_ = buf.WriteByte(byte(len(p.Method)))
+	_, _ = buf.Write([]byte(p.Method))
+	_, _ = buf.Write([]byte(p.Data))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Auth) Unpack(buf []byte) error {
+	if len(buf) < int(authHeaderLength) {
+		return fmt.Errorf("bad AUTH2 packet length: expected >=%d, got %d",
+			authHeaderLength, len(buf))
+	}
+
+	p.ReasonCode = ReasonCode(buf[0])
+	methodLen := uint16(buf[1])
+
+	if len(buf) < int(authHeaderLength+methodLen) {
+		return fmt.Errorf("bad AUTH2 packet length: expected >=%d, got %d",
+			authHeaderLength+methodLen, len(buf))
+	}
+
+	p.Method = string(buf[authHeaderLength : authHeaderLength+methodLen])
+	p.Data = buf[authHeaderLength+methodLen:]
+
+	return nil
+}
+
+func (p Auth) String() string {
+	// We intentionally do not print Data because it contains sensitive data.
+	return fmt.Sprintf("AUTH2(ReasonCode=%s, Method=%#v)", p.ReasonCode, p.Method)
+}
+
+func (p *Auth) computeLength() {
+	methodLen := uint16(len(p.Method))
+	dataLen := uint16(len(p.Data))
+	p.Header.SetVarPartLength(authHeaderLength + methodLen + dataLen)
+}

--- a/packets2/auth_test.go
+++ b/packets2/auth_test.go
@@ -1,0 +1,117 @@
+package packets2
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestAuthPlainConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	user := "test-user"
+	password := []byte("test-password")
+	pkt := NewAuthPlain(user, password)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Auth", reflect.TypeOf(pkt).String(), "Type should be Auth")
+	assert.Equal(RC_SUCCESS, pkt.ReasonCode, "Bad ReasonCode value")
+	assert.Equal("PLAIN", pkt.Method, "Bad Method value")
+	assert.Equal(
+		[]byte(fmt.Sprintf("\x00%s\x00%s", user, password)),
+		pkt.Data, "Bad Data value")
+}
+
+func TestAuthPlainMarshal(t *testing.T) {
+	pkt1 := NewAuthPlain("test-user", []byte("test-password"))
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Auth))
+}
+
+func TestAuthUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short - Method Length missing.
+	buff := bytes.NewBuffer([]byte{
+		3,               // Length
+		byte(pkts.AUTH), // PktType
+		0,               // Reason Code
+		// Method Length missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad AUTH2 packet length")
+	}
+
+	// Packet too short - Method missing.
+	buff = bytes.NewBuffer([]byte{
+		4,               // Length
+		byte(pkts.AUTH), // PktType
+		0,               // Reason Code
+		1,               // Method Length
+		// Method missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad AUTH2 packet length")
+	}
+}
+
+func TestAuthDecodePlain(t *testing.T) {
+	assert := assert.New(t)
+
+	user := "test-user"
+	password := []byte("test-password")
+
+	// Correct PLAIN data.
+	buff := bytes.NewBuffer([]byte{
+		11 + byte(len(user)+len(password)), // Length
+		byte(pkts.AUTH),                    // PktType
+		0,                                  // Reason
+		5,                                  // Method Length
+		'P', 'L', 'A', 'I', 'N',            // Method
+	})
+	// Data
+	buff.WriteByte(0)
+	buff.Write([]byte(user))
+	buff.WriteByte(0)
+	buff.Write(password)
+
+	pkt, err := ReadPacket(buff)
+	assert.Nil(err)
+
+	user2, password2, err := pkt.(*Auth).DecodePlain()
+	assert.Nil(err)
+	assert.Equal(user, user2)
+	assert.Equal(password, password2)
+
+	// Invalid PLAIN data.
+	buff = bytes.NewBuffer([]byte{
+		11,                      // Length
+		byte(pkts.AUTH),         // PktType
+		0,                       // Reason
+		5,                       // Method Length
+		'P', 'L', 'A', 'I', 'N', // Method
+		0, 1, // Data (do not contain two zero bytes)
+	})
+	pkt, err = ReadPacket(buff)
+	assert.Nil(err)
+
+	_, _, err = pkt.(*Auth).DecodePlain()
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "invalid PLAIN auth data format")
+	}
+}
+
+func TestAuthStringer(t *testing.T) {
+	pkt := NewAuthPlain("test-user", []byte("test-password"))
+	assert.Equal(t, "AUTH2(ReasonCode=success, Method=\"PLAIN\")", pkt.String())
+}

--- a/packets2/connack.go
+++ b/packets2/connack.go
@@ -1,0 +1,90 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const connackHeaderLength uint16 = 6
+const connackSessionPresentBit uint8 = 1
+
+type Connack struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	SessionPresent bool
+	// Fields
+	ReasonCode               ReasonCode
+	SessionExpiryInterval    uint32
+	AssignedClientIdentifier string
+}
+
+func NewConnack(reasonCode ReasonCode, sessExpiry uint32, assignedClientID string,
+	sessPresent bool) *Connack {
+	p := &Connack{
+		Header:                   *pkts.NewHeader(pkts.CONNACK, 0),
+		SessionPresent:           sessPresent,
+		ReasonCode:               reasonCode,
+		SessionExpiryInterval:    sessExpiry,
+		AssignedClientIdentifier: assignedClientID,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Connack) computeLength() {
+	assignedClientIDLength := uint16(len(p.AssignedClientIdentifier))
+	p.Header.SetVarPartLength(connackHeaderLength + assignedClientIDLength)
+}
+
+func (p *Connack) decodeFlags(b byte) {
+	p.SessionPresent = (b & connackSessionPresentBit) == connackSessionPresentBit
+}
+
+func (p *Connack) encodeFlags() byte {
+	var b byte
+	if p.SessionPresent {
+		b |= connackSessionPresentBit
+	}
+	return b
+}
+
+// NOTE: The MQTT-SN v. 2.0 specification draft WD20 states that both
+// SessionExpiryInterval and AssignedClientIdentifier are optional (chapter
+// 2.1.5 CONNACK) but there is no means to signalize which one is or is not
+// present. I consider this a bug in the specification. I'm fixing it
+// temporarily by just considering SessionExpiryInterval mandatory.
+func (p *Connack) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(byte(p.ReasonCode))
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint32(p.SessionExpiryInterval))
+	if p.AssignedClientIdentifier != "" {
+		_, _ = buf.Write([]byte(p.AssignedClientIdentifier))
+	}
+
+	return buf.Bytes(), nil
+}
+
+// NOTE: SessionExpiryInterval considered mandatory here, see NOTE for Pack().
+func (p *Connack) Unpack(buf []byte) error {
+	if len(buf) < int(connackHeaderLength) {
+		return fmt.Errorf("bad CONNACK2 packet length: expected >=%d, got %d",
+			connackHeaderLength, len(buf))
+	}
+
+	p.ReasonCode = ReasonCode(buf[0])
+	p.decodeFlags(buf[1])
+	p.SessionExpiryInterval = binary.BigEndian.Uint32(buf[2:6])
+	p.AssignedClientIdentifier = string(buf[6:])
+
+	return nil
+}
+
+func (p Connack) String() string {
+	return fmt.Sprintf("CONNACK2(ReasonCode=%d,AssClientId=%q,SessExpiry=%d,SessPresent=%t)",
+		p.ReasonCode, p.AssignedClientIdentifier, p.SessionExpiryInterval, p.SessionPresent)
+}

--- a/packets2/connack_test.go
+++ b/packets2/connack_test.go
@@ -1,0 +1,60 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestConnackConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	reasonCode := RC_CONGESTION
+	sessExpiry := uint32(1234)
+	assignedClientID := "client-id"
+	sessPresent := true
+	pkt := NewConnack(reasonCode, sessExpiry, assignedClientID, sessPresent)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Connack", reflect.TypeOf(pkt).String(), "Type should be Connack")
+	assert.Equal(reasonCode, pkt.ReasonCode, "Invalid ReasonCode")
+	assert.Equal(sessExpiry, pkt.SessionExpiryInterval, "Invalid SessionExpiryInterval")
+	assert.Equal(assignedClientID, pkt.AssignedClientIdentifier, "Invalid AssignedClientIdentifier")
+	assert.Equal(2+connackHeaderLength+uint16(len(assignedClientID)), pkt.PacketLength(), "Invalid PacketLength")
+}
+
+func TestConnackMarshal(t *testing.T) {
+	pkt1 := NewConnack(RC_CONGESTION, 1234, "client-id", true)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Connack))
+}
+
+func TestConnackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		7,                  // Length
+		byte(pkts.CONNACK), // Packet Type
+		0,                  // Reason Code
+		0,                  // Flags
+		0, 0, 0,            // Session Expiry Interval (without LSB)
+		// Session Expiry Interval LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad CONNACK2 packet length")
+	}
+}
+
+func TestConnackStringer(t *testing.T) {
+	pkt := NewConnack(RC_CONGESTION, 1234, "client-id", true)
+	assert.Equal(t, `CONNACK2(ReasonCode=1,AssClientId="client-id",SessExpiry=1234,SessPresent=true)`, pkt.String())
+}

--- a/packets2/connect.go
+++ b/packets2/connect.go
@@ -1,0 +1,112 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const connectHeaderLength uint16 = 10
+const connectCleanStartBit uint8 = 1 << 0
+const connectWillBit uint8 = 1 << 1
+const connectAuthBit uint8 = 1 << 2
+
+type Connect struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	Authentication bool
+	Will           bool
+	CleanStart     bool
+	// Fields
+	ProtocolVersion       uint8
+	KeepAlive             uint16
+	SessionExpiryInterval uint32
+	MaxPacketSize         uint16
+	ClientIdentifier      string
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewConnect(keepAlive uint16, sessExpiry uint32, maxPktSize uint16, clientID string,
+	auth bool, will bool, cleanStart bool) *Connect {
+	p := &Connect{
+		Header:                *pkts.NewHeader(pkts.CONNECT, 0),
+		Authentication:        auth,
+		Will:                  will,
+		CleanStart:            cleanStart,
+		ProtocolVersion:       0x02,
+		KeepAlive:             keepAlive,
+		SessionExpiryInterval: sessExpiry,
+		MaxPacketSize:         maxPktSize,
+		ClientIdentifier:      clientID,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Connect) computeLength() {
+	clientIDLength := uint16(len(p.ClientIdentifier))
+	p.Header.SetVarPartLength(connectHeaderLength + clientIDLength)
+}
+
+func (p *Connect) decodeFlags(b byte) {
+	p.CleanStart = (b & connectCleanStartBit) == connectCleanStartBit
+	p.Will = (b & connectWillBit) == connectWillBit
+	p.Authentication = (b & connectAuthBit) == connectAuthBit
+}
+
+func (p *Connect) encodeFlags() byte {
+	var b byte
+	if p.CleanStart {
+		b |= connectCleanStartBit
+	}
+	if p.Will {
+		b |= connectWillBit
+	}
+	if p.Authentication {
+		b |= connectAuthBit
+	}
+	return b
+}
+
+func (p *Connect) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.encodeFlags())
+	_ = buf.WriteByte(p.ProtocolVersion)
+	_, _ = buf.Write(pkts.EncodeUint16(p.KeepAlive))
+	_, _ = buf.Write(pkts.EncodeUint32(p.SessionExpiryInterval))
+	_, _ = buf.Write(pkts.EncodeUint16(p.MaxPacketSize))
+	_, _ = buf.Write([]byte(p.ClientIdentifier))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Connect) Unpack(buf []byte) error {
+	if len(buf) <= int(connectHeaderLength) {
+		return fmt.Errorf("bad CONNECT2 packet length: expected >%d, got %d",
+			connectHeaderLength, len(buf))
+	}
+
+	p.decodeFlags(buf[0])
+	p.ProtocolVersion = buf[1]
+	if p.ProtocolVersion != 2 {
+		return fmt.Errorf("bad CONNECT2 ProtocolVersion: expected 2, got %d", buf[1])
+	}
+	p.KeepAlive = binary.BigEndian.Uint16(buf[2:4])
+	p.SessionExpiryInterval = binary.BigEndian.Uint32(buf[4:8])
+	p.MaxPacketSize = binary.BigEndian.Uint16(buf[8:10])
+	p.ClientIdentifier = string(buf[10:])
+
+	return nil
+}
+
+func (p Connect) String() string {
+	return fmt.Sprintf(
+		"CONNECT2(ClientID=%q, CleanStart=%t, Will=%t, Auth=%t, SessExpiry=%d, KeepAlive=%d, MaxPktSize=%d)",
+		p.ClientIdentifier, p.CleanStart, p.Will, p.Authentication,
+		p.SessionExpiryInterval, p.KeepAlive, p.MaxPacketSize,
+	)
+}

--- a/packets2/connect_test.go
+++ b/packets2/connect_test.go
@@ -1,0 +1,83 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestConnectConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	keepAlive := uint16(1234)
+	sessExpiry := uint32(123456)
+	maxPktSize := uint16(2345)
+	clientID := "test-client"
+	auth := true
+	will := true
+	cleanStart := true
+	pkt := NewConnect(keepAlive, sessExpiry, maxPktSize, clientID, auth, will, cleanStart)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Connect", reflect.TypeOf(pkt).String(), "Type should be Connect")
+	assert.Equal(keepAlive, pkt.KeepAlive, "Bad KeepAlive value")
+	assert.Equal(sessExpiry, pkt.SessionExpiryInterval, "Bad SessionExpiryInterval value")
+	assert.Equal(maxPktSize, pkt.MaxPacketSize, "Bad MaxPacketSize value")
+	assert.Equal(clientID, pkt.ClientIdentifier, "Bad ClientIdentifier value")
+	assert.Equal(auth, pkt.Authentication, "Bad Authentication value")
+	assert.Equal(will, pkt.Will, "Bad Will value")
+	assert.Equal(cleanStart, pkt.CleanStart, "Bad CleanStart value")
+	assert.Equal(uint8(2), pkt.ProtocolVersion, "ProtocolVersion should be 2")
+}
+
+func TestConnectMarshal(t *testing.T) {
+	pkt1 := NewConnect(1234, 123456, 2345, "test-client", true, true, true)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Connect))
+}
+
+func TestConnectUnmarshalInvalid(t *testing.T) {
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		12,                 // Length
+		byte(pkts.CONNECT), // Packet Type
+		0,                  // Flags
+		2,                  // Protocol Version
+		0, 0,               // Keep Alive
+		0, 0, 0, 0, // Session Expiry Interval
+		0, 0, // Max Packet Size
+		// Client Identifier missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad CONNECT2 packet length")
+	}
+
+	// Invalid protocol version.
+	buff = bytes.NewBuffer([]byte{
+		13,                 // Length
+		byte(pkts.CONNECT), // Packet Type
+		0,                  // Flags
+		1,                  // Protocol Version
+		0, 0,               // Keep Alive
+		0, 0, 0, 0, // Session Expiry Interval
+		0, 0, // Max Packet Size
+		byte('a'), // Client Identifier
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad CONNECT2 ProtocolVersion")
+	}
+}
+
+func TestConnectStringer(t *testing.T) {
+	pkt := NewConnect(1234, 123456, 2345, "test-client", true, true, true)
+	assert.Equal(t, `CONNECT2(ClientID="test-client", CleanStart=true, Will=true, Auth=true, SessExpiry=123456, KeepAlive=1234, MaxPktSize=2345)`, pkt.String())
+}

--- a/packets2/disconnect.go
+++ b/packets2/disconnect.go
@@ -1,0 +1,71 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/energomonitor/bisquitt/packets"
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+// TODO: Current specification draft (WD20) says that all fields are optional but
+// it's unclear how missing fields should be signalized in the packet. Therefore
+// I implement all the fields as mandatory for now.
+
+const disconnectHeaderLength uint16 = 5
+
+type Disconnect struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	ReasonCode            ReasonCode
+	SessionExpiryInterval uint32
+	ReasonString          string
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewDisconnect(reasonCode ReasonCode, sessExpiry uint32, reasonString string) *Disconnect {
+	p := &Disconnect{
+		Header:                *pkts.NewHeader(pkts.DISCONNECT, 0),
+		ReasonCode:            reasonCode,
+		SessionExpiryInterval: sessExpiry,
+		ReasonString:          reasonString,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Disconnect) computeLength() {
+	p.Header.SetVarPartLength(disconnectHeaderLength + uint16(len(p.ReasonString)))
+}
+
+func (p *Disconnect) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(uint8(p.ReasonCode))
+
+	expiryEncoded := packets.EncodeUint32(p.SessionExpiryInterval)
+	_, _ = buf.Write(expiryEncoded)
+	_, _ = buf.Write([]byte(p.ReasonString))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Disconnect) Unpack(buf []byte) error {
+	if len(buf) < int(disconnectHeaderLength) {
+		return fmt.Errorf("bad DISCONNECT2 packet length: expected >=%d, got %d",
+			disconnectHeaderLength, len(buf))
+	}
+
+	p.ReasonCode = ReasonCode(buf[0])
+	p.SessionExpiryInterval = binary.BigEndian.Uint32(buf[1:5])
+	p.ReasonString = string(buf[5:])
+
+	return nil
+}
+
+func (p Disconnect) String() string {
+	return fmt.Sprintf("DISCONNECT2(ReasonCode=%s, Reason=%q, SessExpiry=%d)",
+		p.ReasonCode, p.ReasonString, p.SessionExpiryInterval)
+}

--- a/packets2/disconnect_test.go
+++ b/packets2/disconnect_test.go
@@ -1,0 +1,55 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestDisconnectConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	reasonCode := RC_CONGESTION
+	sessExpiry := uint32(123456)
+	reasonString := "test reason"
+	pkt := NewDisconnect(reasonCode, sessExpiry, reasonString)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Disconnect", reflect.TypeOf(pkt).String(), "Type should be Disconnect")
+	assert.Equal(reasonCode, pkt.ReasonCode, "Bad ReasonCode value")
+	assert.Equal(sessExpiry, pkt.SessionExpiryInterval, "Bad SessionExpiryInterval value")
+	assert.Equal(reasonString, pkt.ReasonString, "Bad ReasonString value")
+}
+
+func TestDisconnectMarshal(t *testing.T) {
+	pkt1 := NewDisconnect(RC_CONGESTION, uint32(123456), "test reason")
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Disconnect))
+}
+
+func TestDisconnectUnmarshal(t *testing.T) {
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		6,                     // Length
+		byte(pkts.DISCONNECT), // Packet Type
+		0,                     // Reason Code
+		0, 0, 0,               // Session Expiry Interval (without LSB)
+		// Session Expiry Interval LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad DISCONNECT2 packet length")
+	}
+}
+
+func TestDisconnectStringer(t *testing.T) {
+	pkt := NewDisconnect(RC_CONGESTION, uint32(123456), "test reason")
+	assert.Equal(t, `DISCONNECT2(ReasonCode=congestion, Reason="test reason", SessExpiry=123456)`, pkt.String())
+}

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -115,8 +115,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &SearchGw{Header: h}
 	case pkts.GWINFO:
 		pkt = &GwInfo{Header: h}
-	//case pkts.AUTH:
-	//	pkt = &Auth{Header: h}
+	case pkts.AUTH:
+		pkt = &Auth{Header: h}
 	//case pkts.CONNECT:
 	//	pkt = &Connect{Header: h}
 	//case pkts.CONNACK:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -117,8 +117,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &GwInfo{Header: h}
 	case pkts.AUTH:
 		pkt = &Auth{Header: h}
-	//case pkts.CONNECT:
-	//	pkt = &Connect{Header: h}
+	case pkts.CONNECT:
+		pkt = &Connect{Header: h}
 	case pkts.CONNACK:
 		pkt = &Connack{Header: h}
 	//case pkts.WILLTOPICREQ:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -119,8 +119,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Auth{Header: h}
 	//case pkts.CONNECT:
 	//	pkt = &Connect{Header: h}
-	//case pkts.CONNACK:
-	//	pkt = &Connack{Header: h}
+	case pkts.CONNACK:
+		pkt = &Connack{Header: h}
 	//case pkts.WILLTOPICREQ:
 	//	pkt = &WillTopicReq{Header: h}
 	//case pkts.WILLTOPIC:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -155,8 +155,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &Pingreq{Header: h}
 	//case pkts.PINGRESP:
 	//	pkt = &Pingresp{Header: h}
-	//case pkts.DISCONNECT:
-	//	pkt = &Disconnect{Header: h}
+	case pkts.DISCONNECT:
+		pkt = &Disconnect{Header: h}
 	//case pkts.WILLTOPICUPD:
 	//	pkt = &WillTopicUpd{Header: h}
 	//case pkts.WILLTOPICRESP:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -151,8 +151,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &Unsubscribe{Header: h}
 	//case pkts.UNSUBACK:
 	//	pkt = &Unsuback{Header: h}
-	//case pkts.PINGREQ:
-	//	pkt = &Pingreq{Header: h}
+	case pkts.PINGREQ:
+		pkt = &Pingreq{Header: h}
 	//case pkts.PINGRESP:
 	//	pkt = &Pingresp{Header: h}
 	case pkts.DISCONNECT:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -153,8 +153,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &Unsuback{Header: h}
 	case pkts.PINGREQ:
 		pkt = &Pingreq{Header: h}
-	//case pkts.PINGRESP:
-	//	pkt = &Pingresp{Header: h}
+	case pkts.PINGRESP:
+		pkt = &Pingresp{Header: h}
 	case pkts.DISCONNECT:
 		pkt = &Disconnect{Header: h}
 	//case pkts.WILLTOPICUPD:

--- a/packets2/pingreq.go
+++ b/packets2/pingreq.go
@@ -1,0 +1,78 @@
+package packets2
+
+import (
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+type Pingreq struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	MaxMessages uint8
+	ClientID    string
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewPingreq(maxMessages uint8, clientID string) *Pingreq {
+	p := &Pingreq{
+		Header:      *pkts.NewHeader(pkts.PINGREQ, 0),
+		MaxMessages: maxMessages,
+		ClientID:    clientID,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Pingreq) computeLength() {
+	length := len(p.ClientID)
+	p.Header.SetVarPartLength(uint16(length))
+}
+
+// NOTE: The MQTT-SN v. 2.0 specification draft WD20 states that both
+// MaxMessages and ClientID are optional (chapter 2.1.22 PINGREQ)
+// but there is no means to signalize which one is or is not
+// present.
+// The specification also says that these properties are used by a sleeping
+// client (2.1.22.2 and 2.1.22.3).
+// Even when the specification does not state this explicitly, I deduce that
+// there are 2 possible uses of the PINGREQ packet:
+// 1. an "I am alive!" packet without MaxMessages nor ClientID
+// 2. an "I am going from asleep to awake" packet containing both MaxMessages
+//    and ClientID
+// In Bisquitt, the former use case is signalized by an empty ClientID.
+func (p *Pingreq) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	if len(p.ClientID) > 0 {
+		_ = buf.WriteByte(p.MaxMessages)
+		_, _ = buf.Write([]byte(p.ClientID))
+	}
+
+	return buf.Bytes(), nil
+}
+
+// NOTE: Both MaxMessages and ClientID must be present or missing, see NOTE for Pack().
+func (p *Pingreq) Unpack(buf []byte) error {
+	if len(buf) == 1 {
+		return fmt.Errorf("bad PINGREQ2 packet length: expected 0 or >=2, got %d",
+			len(buf))
+	}
+
+	if len(buf) >= 2 {
+		p.MaxMessages = buf[0]
+		p.ClientID = string(buf[1:])
+	}
+
+	return nil
+}
+
+func (p Pingreq) String() string {
+	if len(p.ClientID) == 0 {
+		return "PINGREQ2"
+	}
+	return fmt.Sprintf("PINGREQ2(MaxMessages=%d, ClientID=%q)",
+		p.MaxMessages, p.ClientID)
+}

--- a/packets2/pingreq_test.go
+++ b/packets2/pingreq_test.go
@@ -1,0 +1,82 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPingreqConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	maxMessages := uint8(123)
+	clientID := "test-client"
+	pkt := NewPingreq(maxMessages, clientID)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Pingreq", reflect.TypeOf(pkt).String(), "Type should be Pingreq")
+	assert.Equal(maxMessages, pkt.MaxMessages, "Bad MaxMessages value")
+	assert.Equal(clientID, pkt.ClientID, "Bad ClientID value")
+}
+
+func TestPingreqMarshal(t *testing.T) {
+	// Packet without MaxMessages and ClientID.
+	pkt1 := NewPingreq(0, "")
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pingreq))
+
+	// Packet with MaxMessages and ClientID.
+	pkt1 = NewPingreq(123, "test-client")
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pingreq))
+}
+
+func TestPingreqUnmarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet without MaxMessages and ClientID is correct (length=2).
+	buff := bytes.NewBuffer([]byte{
+		2,                  // Length
+		byte(pkts.PINGREQ), // Packet Type
+	})
+	_, err := ReadPacket(buff)
+	assert.Nil(err)
+
+	// Packet too short (length=3).
+	buff = bytes.NewBuffer([]byte{
+		3,                  // Length
+		byte(pkts.PINGREQ), // Packet Type
+		0,                  // Max Messages
+		// Client Identifier missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PINGREQ2 packet length")
+	}
+
+	// Packet with MaxMessages and ClientID is correct (length=4).
+	buff = bytes.NewBuffer([]byte{
+		4,                  // Length
+		byte(pkts.PINGREQ), // Packet Type
+		0,                  // Max Messages
+		byte('a'),          // Client Identifier
+	})
+	_, err = ReadPacket(buff)
+	assert.Nil(err)
+}
+
+func TestPingreqStringer(t *testing.T) {
+	// Packet without MaxMessages and ClientID.
+	pkt := NewPingreq(0, "")
+	assert.Equal(t, `PINGREQ2`, pkt.String())
+
+	// Packet with MaxMessages and ClientID.
+	pkt = NewPingreq(123, "test-client")
+	assert.Equal(t, `PINGREQ2(MaxMessages=123, ClientID="test-client")`, pkt.String())
+}

--- a/packets2/pingresp.go
+++ b/packets2/pingresp.go
@@ -1,0 +1,68 @@
+package packets2
+
+import (
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const pingrespHeaderLength uint16 = 0
+
+type Pingresp struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	MessagesRemaining uint8
+	// Auxiliary
+	MessagesRemainingPresent bool
+}
+
+func NewPingresp(msgsRemaining uint8, msgsRemainingPresent bool) *Pingresp {
+	p := &Pingresp{
+		Header:                   *pkts.NewHeader(pkts.PINGRESP, 0),
+		MessagesRemaining:        msgsRemaining,
+		MessagesRemainingPresent: msgsRemainingPresent,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Pingresp) computeLength() {
+	if p.MessagesRemainingPresent {
+		p.Header.SetVarPartLength(pingrespHeaderLength + 1)
+	} else {
+		p.Header.SetVarPartLength(pingrespHeaderLength)
+	}
+}
+
+func (p *Pingresp) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	if p.MessagesRemainingPresent {
+		_ = buf.WriteByte(p.MessagesRemaining)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (p *Pingresp) Unpack(buf []byte) error {
+	switch len(buf) {
+	case 0:
+		p.MessagesRemainingPresent = false
+		return nil
+	case 1:
+		p.MessagesRemainingPresent = true
+		p.MessagesRemaining = buf[0]
+		return nil
+	default:
+		return fmt.Errorf("bad PINGRESP2 packet length: expected <=1, got %d",
+			len(buf))
+	}
+}
+
+func (p Pingresp) String() string {
+	if p.MessagesRemainingPresent {
+		return fmt.Sprintf("PINGRESP2(MsgsRemaining=%d)", p.MessagesRemaining)
+	}
+	return "PINGRESP2"
+}

--- a/packets2/pingresp_test.go
+++ b/packets2/pingresp_test.go
@@ -1,0 +1,65 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPingrespConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	msgsRemaining := uint8(123)
+	msgsRemainingPresent := true
+	pkt := NewPingresp(msgsRemaining, msgsRemainingPresent)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Pingresp", reflect.TypeOf(pkt).String(), "Type should be Pingresp")
+	assert.Equal(msgsRemaining, pkt.MessagesRemaining, "Bad MessagesRemaining value")
+	assert.Equal(msgsRemainingPresent, pkt.MessagesRemainingPresent, "Bad MessagesRemainingPresent value")
+	assert.Equal(uint16(3), pkt.PacketLength(), "Length should be 3")
+}
+
+func TestPingrespMarshal(t *testing.T) {
+	// Packet without Messages Remaining
+	pkt1 := NewPingresp(0, false)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pingresp))
+
+	// Packet with Messages Remaining
+	pkt1 = NewPingresp(123, true)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pingresp))
+}
+
+func TestPingrespUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too long.
+	buff := bytes.NewBuffer([]byte{
+		6,                   // Length
+		byte(pkts.PINGRESP), // Packet Type
+		0,                   // Messages Remaining
+		0,                   // junk
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PINGRESP2 packet length")
+	}
+}
+
+func TestPingrespStringer(t *testing.T) {
+	// Packet without Messages Remaining
+	pkt := NewPingresp(0, false)
+	assert.Equal(t, "PINGRESP2", pkt.String())
+
+	// Packet with Messages Remaining
+	pkt = NewPingresp(123, true)
+	assert.Equal(t, "PINGRESP2(MsgsRemaining=123)", pkt.String())
+}


### PR DESCRIPTION
PR adds connection-related packets: `Auth`, `Connect`, `Connack`, `Disconnect`, `Pingresp`, `Pingreq`.

Failed tests are OK. They will pass as long as all packets are merged in.