### PR TITLE
packets2: Add publish-related packets

### DIFF
--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -139,8 +139,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Puback{Header: h}
 	case pkts.PUBCOMP:
 		pkt = &Pubcomp{Header: h}
-	//case pkts.PUBREC:
-	//	pkt = &Pubrec{Header: h}
+	case pkts.PUBREC:
+		pkt = &Pubrec{Header: h}
 	//case pkts.PUBREL:
 	//	pkt = &Pubrel{Header: h}
 	//case pkts.SUBSCRIBE:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -135,8 +135,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &Regack{Header: h}
 	//case pkts.PUBLISH:
 	//	pkt = &Publish{Header: h}
-	//case pkts.PUBACK:
-	//	pkt = &Puback{Header: h}
+	case pkts.PUBACK:
+		pkt = &Puback{Header: h}
 	//case pkts.PUBCOMP:
 	//	pkt = &Pubcomp{Header: h}
 	//case pkts.PUBREC:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -133,8 +133,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &Register{Header: h}
 	//case pkts.REGACK:
 	//	pkt = &Regack{Header: h}
-	//case pkts.PUBLISH:
-	//	pkt = &Publish{Header: h}
+	case pkts.PUBLISH:
+		pkt = &Publish{Header: h}
 	case pkts.PUBACK:
 		pkt = &Puback{Header: h}
 	case pkts.PUBCOMP:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -137,8 +137,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &Publish{Header: h}
 	case pkts.PUBACK:
 		pkt = &Puback{Header: h}
-	//case pkts.PUBCOMP:
-	//	pkt = &Pubcomp{Header: h}
+	case pkts.PUBCOMP:
+		pkt = &Pubcomp{Header: h}
 	//case pkts.PUBREC:
 	//	pkt = &Pubrec{Header: h}
 	//case pkts.PUBREL:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -141,8 +141,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Pubcomp{Header: h}
 	case pkts.PUBREC:
 		pkt = &Pubrec{Header: h}
-	//case pkts.PUBREL:
-	//	pkt = &Pubrel{Header: h}
+	case pkts.PUBREL:
+		pkt = &Pubrel{Header: h}
 	//case pkts.SUBSCRIBE:
 	//	pkt = &Subscribe{Header: h}
 	//case pkts.SUBACK:

--- a/packets2/property_packet_id_test.go
+++ b/packets2/property_packet_id_test.go
@@ -1,7 +1,11 @@
 package packets2
 
-// TODO: Uncomment as soon as Pubrec and Pubrel types are defined.
-/*
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
 func TestPacketID(t *testing.T) {
 	msgID := uint16(1234)
 
@@ -13,4 +17,3 @@ func TestPacketID(t *testing.T) {
 	pkt2.CopyPacketID(pkt1)
 	assert.Equal(t, msgID, pkt2.PacketID())
 }
-*/

--- a/packets2/puback.go
+++ b/packets2/puback.go
@@ -1,0 +1,51 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const pubackVarPartLength uint16 = 3
+
+type Puback struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	PacketIDProperty
+	ReasonCode ReasonCode
+}
+
+func NewPuback(reasonCode ReasonCode) *Puback {
+	return &Puback{
+		Header:     *pkts.NewHeader(pkts.PUBACK, pubackVarPartLength),
+		ReasonCode: reasonCode,
+	}
+}
+
+func (p *Puback) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	_ = buf.WriteByte(byte(p.ReasonCode))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Puback) Unpack(buf []byte) error {
+	if len(buf) != int(pubackVarPartLength) {
+		return fmt.Errorf("bad PUBACK2 packet length: expected %d, got %d",
+			pubackVarPartLength, len(buf))
+	}
+
+	p.packetID = binary.BigEndian.Uint16(buf[0:2])
+	p.ReasonCode = ReasonCode(buf[2])
+
+	return nil
+}
+
+func (p Puback) String() string {
+	return fmt.Sprintf("PUBACK2(ReasonCode=%s, PacketID=%d)",
+		p.ReasonCode, p.packetID)
+}

--- a/packets2/puback_test.go
+++ b/packets2/puback_test.go
@@ -1,0 +1,68 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestPubackConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	pkt := NewPuback(RC_CONGESTION)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Puback", reflect.TypeOf(pkt).String(), "Type should be Puback")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+	assert.Equal(RC_CONGESTION, pkt.ReasonCode, "ReasonCode should be RC_CONGESTION")
+	assert.Equal(uint16(5), pkt.PacketLength(), "Default Length should be 5")
+}
+
+func TestPubackMarshal(t *testing.T) {
+	pkt1 := NewPuback(RC_CONGESTION)
+	pkt1.SetPacketID(123)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Puback))
+}
+
+func TestPubackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		4,                 // Length
+		byte(pkts.PUBACK), // Packet Type
+		0, 2,              // Packet ID
+		// Reason Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBACK2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		6,                 // Length
+		byte(pkts.PUBACK), // Packet Type
+		0, 2,              // Packet ID
+		0, // Reason Code
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBACK2 packet length")
+	}
+}
+
+func TestPubackStringer(t *testing.T) {
+	pkt := NewPuback(RC_CONGESTION)
+	pkt.SetPacketID(123)
+	assert.Equal(t, "PUBACK2(ReasonCode=congestion, PacketID=123)", pkt.String())
+}

--- a/packets2/pubcomp.go
+++ b/packets2/pubcomp.go
@@ -1,0 +1,46 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const pubcompVarPartLength uint16 = 2
+
+type Pubcomp struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	PacketIDProperty
+}
+
+func NewPubcomp() *Pubcomp {
+	return &Pubcomp{
+		Header: *pkts.NewHeader(pkts.PUBCOMP, pubcompVarPartLength),
+	}
+}
+
+func (p *Pubcomp) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Pubcomp) Unpack(buf []byte) error {
+	if len(buf) != int(pubcompVarPartLength) {
+		return fmt.Errorf("bad PUBCOMP2 packet length: expected %d, got %d",
+			pubcompVarPartLength, len(buf))
+	}
+
+	p.packetID = binary.BigEndian.Uint16(buf)
+
+	return nil
+}
+
+func (p Pubcomp) String() string {
+	return fmt.Sprintf("PUBCOMP2(PacketID=%d)", p.packetID)
+}

--- a/packets2/pubcomp_test.go
+++ b/packets2/pubcomp_test.go
@@ -1,0 +1,66 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestPubcompConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	pkt := NewPubcomp()
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Pubcomp", reflect.TypeOf(pkt).String(), "Type should be Pubcomp")
+	assert.Equal(uint16(4), pkt.PacketLength(), "Default Length should be 4")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestPubcompMarshal(t *testing.T) {
+	pkt1 := NewPubcomp()
+	pkt1.SetPacketID(1234)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pubcomp))
+}
+
+func TestPubcompUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                  // Length
+		byte(pkts.PUBCOMP), // PktType
+		0,                  // Packet ID MSB
+		// Packet ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBCOMP2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                  // Length
+		byte(pkts.PUBCOMP), // PktType
+		0, 1,               // Packet ID
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBCOMP2 packet length")
+	}
+}
+
+func TestPubcompStringer(t *testing.T) {
+	pkt := NewPubcomp()
+	pkt.SetPacketID(1234)
+	assert.Equal(t, "PUBCOMP2(PacketID=1234)", pkt.String())
+}

--- a/packets2/publish.go
+++ b/packets2/publish.go
@@ -1,0 +1,157 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const publishHeaderLength uint16 = 5
+
+type Publish struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	pkts.DUPProperty
+	QOS            uint8
+	Retain         bool
+	TopicAliasType TopicAliasType
+	// Fields
+	PacketIDProperty
+	TopicAlias uint16
+	TopicName  string
+	Data       []byte
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewPublish(topicAlias uint16, topicName string, data []byte,
+	dup bool, qos uint8, retain bool, topicAliasType TopicAliasType) *Publish {
+	p := &Publish{
+		Header:         *pkts.NewHeader(pkts.PUBLISH, 0),
+		DUPProperty:    *pkts.NewDUPProperty(dup),
+		QOS:            qos,
+		Retain:         retain,
+		TopicAliasType: topicAliasType,
+		TopicAlias:     topicAlias,
+		TopicName:      topicName,
+		Data:           data,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Publish) topicLength() uint16 {
+	if p.TopicAliasType == TAT_LONG {
+		return uint16(len(p.TopicName))
+	}
+	return 2
+}
+
+func (p *Publish) computeLength() {
+	dataLen := uint16(len(p.Data))
+	p.Header.SetVarPartLength(publishHeaderLength + p.topicLength() + dataLen)
+}
+
+func (p *Publish) encodeFlags() byte {
+	var b byte
+
+	if p.DUP() {
+		b |= flagsDUPBit
+	}
+	b |= (p.QOS << 5) & flagsQOSBits
+	if p.Retain {
+		b |= flagsRetainBit
+	}
+	b |= uint8(p.TopicAliasType) & flagsTopicAliasTypeBits
+
+	return b
+}
+
+func (p *Publish) decodeFlags(b byte) {
+	p.SetDUP((b & flagsDUPBit) == flagsDUPBit)
+	p.QOS = (b & flagsQOSBits) >> 5
+	p.Retain = (b & flagsRetainBit) == flagsRetainBit
+	p.TopicAliasType = TopicAliasType(b & flagsTopicAliasTypeBits)
+}
+
+func (p *Publish) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.topicLength()))
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+
+	if p.TopicAliasType == TAT_LONG {
+		_, _ = buf.Write([]byte(p.TopicName))
+	} else {
+		_, _ = buf.Write(pkts.EncodeUint16(p.TopicAlias))
+	}
+
+	_, _ = buf.Write(p.Data)
+
+	return buf.Bytes(), nil
+}
+
+func (p *Publish) Unpack(buf []byte) error {
+	if len(buf) < int(publishHeaderLength) {
+		return fmt.Errorf("bad PUBLISH2 packet length: expected >=%d, got %d",
+			publishHeaderLength, len(buf))
+	}
+
+	p.decodeFlags(buf[0])
+	topicLength := binary.BigEndian.Uint16(buf[1:3])
+	p.packetID = binary.BigEndian.Uint16(buf[3:5])
+
+	if len(buf) < int(publishHeaderLength+topicLength) {
+		return fmt.Errorf("bad PUBLISH2 packet length: expected >=%d, got %d",
+			publishHeaderLength+topicLength, len(buf))
+	}
+
+	if p.TopicAliasType == TAT_LONG {
+		// MQTT 5 explicitly forbids zero-length topic:
+		// It is a Protocol Error if the Topic Name is zero length and
+		// there is no Topic Alias.
+		// (MQTT 5.0 specification, 3.3.2.1 Topic Name)
+		if topicLength == 0 {
+			return fmt.Errorf("bad PUBLISH2 topic length: expected >0, got %d",
+				topicLength)
+		}
+		p.TopicName = string(buf[publishHeaderLength : publishHeaderLength+topicLength])
+		p.TopicAlias = 0
+		p.Data = buf[publishHeaderLength+topicLength:]
+	} else {
+		if topicLength != 2 {
+			return fmt.Errorf("bad PUBLISH2 topic length: expected 2, got %d",
+				topicLength)
+		}
+		p.TopicName = ""
+		p.TopicAlias = binary.BigEndian.Uint16(buf[publishHeaderLength : publishHeaderLength+2])
+		p.Data = buf[publishHeaderLength+2:]
+	}
+
+	return nil
+}
+
+func (p Publish) String() string {
+	var topicStr string
+	switch p.TopicAliasType {
+	case TAT_NORMAL:
+		fallthrough
+	case TAT_PREDEFINED:
+		topicStr = fmt.Sprintf("TopicAlias(%s)=%d",
+			p.TopicAliasType, p.TopicAlias)
+	case TAT_SHORT:
+		topicStr = fmt.Sprintf("Topic(%s)=%q",
+			p.TopicAliasType, pkts.DecodeShortTopic(p.TopicAlias))
+	case TAT_LONG:
+		topicStr = fmt.Sprintf("Topic(%s)=%q",
+			p.TopicAliasType, p.TopicName)
+	default:
+		topicStr = fmt.Sprintf("Topic=%q, TopicAlias=%d, TopicAliasType=%s",
+			p.TopicName, p.TopicAlias, p.TopicAliasType)
+	}
+	return fmt.Sprintf("PUBLISH2(%s, Data=%#v, QOS=%d, Retain=%t, PacketID=%d, Dup=%t)",
+		topicStr, string(p.Data), p.QOS, p.Retain, p.packetID, p.DUP())
+}

--- a/packets2/publish_test.go
+++ b/packets2/publish_test.go
@@ -1,0 +1,276 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestPublishConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	dup := true
+	qos := uint8(1)
+	retain := true
+	aliasType := TAT_SHORT
+	topicAlias := uint16(1234)
+	topicName := "test/topic"
+	data := []byte("test-data")
+	pkt := NewPublish(topicAlias, topicName, data, dup, qos, retain, aliasType)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Publish", reflect.TypeOf(pkt).String(), "Type should be Publish")
+	assert.Equal(topicAlias, pkt.TopicAlias, "Bad TopicAlias value")
+	assert.Equal(topicName, pkt.TopicName, "Bad TopicName value")
+	assert.Equal(data, pkt.Data, "Bad Data value")
+	assert.Equal(dup, pkt.DUP(), "Bad Dup flag value")
+	assert.Equal(qos, pkt.QOS, "Bad QOS value")
+	assert.Equal(retain, pkt.Retain, "Bad Retain flag value")
+	assert.Equal(aliasType, pkt.TopicAliasType, "Bad TopicAliasType value")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestPublishMarshal(t *testing.T) {
+	// Normal alias.
+	pkt1 := NewPublish(1234, "", []byte("test-data"), true, 1, true, TAT_NORMAL)
+	pkt1.SetPacketID(2345)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Publish))
+
+	// Predefined alias.
+	pkt1 = NewPublish(1234, "", []byte("test-data"), true, 1, true, TAT_PREDEFINED)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Publish))
+
+	// Short topic.
+	pkt1 = NewPublish(pkts.EncodeShortTopic("a"), "", []byte("test-data"), true, 1, true, TAT_SHORT)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Publish))
+
+	// Long topic.
+	pkt1 = NewPublish(0, "test-topic", []byte("test-data"), true, 1, true, TAT_LONG)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Publish))
+}
+
+func TestPublishUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		6,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_NORMAL),   // Flags
+		0, 2,               // Topic Length
+		0, // Packet ID MSB
+		// Packet ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 packet length")
+	}
+
+	// Packet too short - normal alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_NORMAL),   // Flags
+		0, 2,               // Topic Length
+		0, 1, // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 packet length")
+	}
+
+	// Packet too short - predefined alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                    // Length
+		byte(pkts.PUBLISH),   // Packet Type
+		byte(TAT_PREDEFINED), // Flags
+		0, 2,                 // Topic Length
+		0, 1, // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 packet length")
+	}
+
+	// Packet too short - short topic.
+	buff = bytes.NewBuffer([]byte{
+		8,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_SHORT),    // Flags
+		0, 2,               // Topic Length
+		0, 1, // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 packet length")
+	}
+
+	// Packet too short - long topic.
+	buff = bytes.NewBuffer([]byte{
+		7,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_LONG),     // Flags
+		0, 2,               // Topic Length
+		0, 1, // Packet ID
+		// Topic missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 packet length")
+	}
+
+	// Topic Length too small - normal alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_NORMAL),   // Flags
+		0, 1,               // Topic Length
+		0, 2, // Packet ID
+		0, // Topic Alias
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+	// Topic Length too big - normal alias.
+	buff = bytes.NewBuffer([]byte{
+		10,                 // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_NORMAL),   // Flags
+		0, 3,               // Topic Length
+		0, 2, // Packet ID
+		0, 3, 4, // Topic Alias
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+	// Topic Length too small - predefined alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                    // Length
+		byte(pkts.PUBLISH),   // Packet Type
+		byte(TAT_PREDEFINED), // Flags
+		0, 1,                 // Topic Length
+		0, 2, // Packet ID
+		0, // Topic Alias
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+	// Topic Length too big - predefined alias.
+	buff = bytes.NewBuffer([]byte{
+		10,                   // Length
+		byte(pkts.PUBLISH),   // Packet Type
+		byte(TAT_PREDEFINED), // Flags
+		0, 3,                 // Topic Length
+		0, 2, // Packet ID
+		0, 3, 4, // Topic Alias
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+	// Topic Length too small - short topic.
+	buff = bytes.NewBuffer([]byte{
+		8,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_SHORT),    // Flags
+		0, 1,               // Topic Length
+		0, 2, // Packet ID
+		0, // Topic Alias
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+	// Topic Length too big - short topic.
+	buff = bytes.NewBuffer([]byte{
+		10,                 // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_SHORT),    // Flags
+		0, 3,               // Topic Length
+		0, 2, // Packet ID
+		0, 3, 4, // Topic Alias
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+	// Topic Length too small - long topic.
+	buff = bytes.NewBuffer([]byte{
+		7,                  // Length
+		byte(pkts.PUBLISH), // Packet Type
+		byte(TAT_LONG),     // Flags
+		0, 0,               // Topic Length
+		0, 2, // Packet ID
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBLISH2 topic length")
+	}
+
+}
+
+func TestPublishStringer(t *testing.T) {
+	// Normal alias.
+	pkt := NewPublish(1234, "", []byte("test-data"), true, 1, true, TAT_NORMAL)
+	pkt.SetPacketID(2345)
+	assert.Equal(t,
+		`PUBLISH2(TopicAlias(normal)=1234, Data="test-data", QOS=1, Retain=true, PacketID=2345, Dup=true)`,
+		pkt.String())
+
+	// Predefined alias.
+	pkt = NewPublish(1234, "", []byte("test-data"), true, 1, true, TAT_PREDEFINED)
+	pkt.SetPacketID(2345)
+	assert.Equal(t,
+		`PUBLISH2(TopicAlias(predefined)=1234, Data="test-data", QOS=1, Retain=true, PacketID=2345, Dup=true)`,
+		pkt.String())
+
+	// Short topic.
+	pkt = NewPublish(pkts.EncodeShortTopic("ab"), "", []byte("test-data"), true, 1, true, TAT_SHORT)
+	pkt.SetPacketID(2345)
+	assert.Equal(t,
+		`PUBLISH2(Topic(short)="ab", Data="test-data", QOS=1, Retain=true, PacketID=2345, Dup=true)`,
+		pkt.String())
+
+	// Long topic.
+	pkt = NewPublish(0, "test-topic", []byte("test-data"), true, 1, true, TAT_LONG)
+	pkt.SetPacketID(2345)
+	assert.Equal(t,
+		`PUBLISH2(Topic(long)="test-topic", Data="test-data", QOS=1, Retain=true, PacketID=2345, Dup=true)`,
+		pkt.String())
+
+	// Illegal topic alias type.
+	pkt = NewPublish(1234, "test-topic", []byte("test-data"), true, 1, true, 5)
+	pkt.SetPacketID(2345)
+	assert.Equal(t,
+		`PUBLISH2(Topic="test-topic", TopicAlias=1234, TopicAliasType=illegal(5), Data="test-data", QOS=1, Retain=true, PacketID=2345, Dup=true)`,
+		pkt.String())
+}

--- a/packets2/pubrec.go
+++ b/packets2/pubrec.go
@@ -1,0 +1,46 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const pubrecVarPartLength uint16 = 2
+
+type Pubrec struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	PacketIDProperty
+}
+
+func NewPubrec() *Pubrec {
+	return &Pubrec{
+		Header: *pkts.NewHeader(pkts.PUBREC, pubrecVarPartLength),
+	}
+}
+
+func (p *Pubrec) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Pubrec) Unpack(buf []byte) error {
+	if len(buf) != int(pubrecVarPartLength) {
+		return fmt.Errorf("bad PUBREC2 packet length: expected %d, got %d",
+			pubrecVarPartLength, len(buf))
+	}
+
+	p.packetID = binary.BigEndian.Uint16(buf)
+
+	return nil
+}
+
+func (p Pubrec) String() string {
+	return fmt.Sprintf("PUBREC2(PacketID=%d)", p.packetID)
+}

--- a/packets2/pubrec_test.go
+++ b/packets2/pubrec_test.go
@@ -1,0 +1,66 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestPubrecConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	pkt := NewPubrec()
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Pubrec", reflect.TypeOf(pkt).String(), "Type should be Pubrec")
+	assert.Equal(uint16(4), pkt.PacketLength(), "Default Length should be 4")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestPubrecMarshal(t *testing.T) {
+	pkt1 := NewPubrec()
+	pkt1.SetPacketID(1234)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pubrec))
+}
+
+func TestPubrecUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                 // Length
+		byte(pkts.PUBREC), // PktType
+		0,                 // Packet ID MSB
+		// Packet ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREC2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                 // Length
+		byte(pkts.PUBREC), // PktType
+		0, 1,              // Packet ID
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREC2 packet length")
+	}
+}
+
+func TestPubrecStringer(t *testing.T) {
+	pkt := NewPubrec()
+	pkt.SetPacketID(1234)
+	assert.Equal(t, "PUBREC2(PacketID=1234)", pkt.String())
+}

--- a/packets2/pubrel.go
+++ b/packets2/pubrel.go
@@ -1,0 +1,46 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const pubrelVarPartLength uint16 = 2
+
+type Pubrel struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	PacketIDProperty
+}
+
+func NewPubrel() *Pubrel {
+	return &Pubrel{
+		Header: *pkts.NewHeader(pkts.PUBREL, pubrelVarPartLength),
+	}
+}
+
+func (p *Pubrel) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Pubrel) Unpack(buf []byte) error {
+	if len(buf) != int(pubrelVarPartLength) {
+		return fmt.Errorf("bad PUBREL2 packet length: expected %d, got %d",
+			pubrelVarPartLength, len(buf))
+	}
+
+	p.packetID = binary.BigEndian.Uint16(buf)
+
+	return nil
+}
+
+func (p Pubrel) String() string {
+	return fmt.Sprintf("PUBREL2(PacketID=%d)", p.packetID)
+}

--- a/packets2/pubrel_test.go
+++ b/packets2/pubrel_test.go
@@ -1,0 +1,66 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestPubrelConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	pkt := NewPubrel()
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Pubrel", reflect.TypeOf(pkt).String(), "Type should be Pubrel")
+	assert.Equal(uint16(4), pkt.PacketLength(), "Default Length should be 4")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestPubrelMarshal(t *testing.T) {
+	pkt1 := NewPubrel()
+	pkt1.SetPacketID(1234)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Pubrel))
+}
+
+func TestPubrelUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		3,                 // Length
+		byte(pkts.PUBREL), // PktType
+		0,                 // Packet ID MSB
+		// Packet ID LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREL2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                 // Length
+		byte(pkts.PUBREL), // PktType
+		0, 1,              // Packet ID
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad PUBREL2 packet length")
+	}
+}
+
+func TestPubrelStringer(t *testing.T) {
+	pkt := NewPubrel()
+	pkt.SetPacketID(1234)
+	assert.Equal(t, "PUBREL2(PacketID=1234)", pkt.String())
+}


### PR DESCRIPTION
PR adds gateway-related packets: `Publish`, `Puback`, `Pubrec`, `Pubrel`, `Pubcomp`.

Failed tests are OK. They will pass as long as all packets are merged in.