### PR TITLE
packets2: Add register and subscribe-related packets

### DIFF
--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -129,8 +129,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &WillMsgReq{Header: h}
 	//case pkts.WILLMSG:
 	//	pkt = &WillMsg{Header: h}
-	//case pkts.REGISTER:
-	//	pkt = &Register{Header: h}
+	case pkts.REGISTER:
+		pkt = &Register{Header: h}
 	case pkts.REGACK:
 		pkt = &Regack{Header: h}
 	case pkts.PUBLISH:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -143,8 +143,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Pubrec{Header: h}
 	case pkts.PUBREL:
 		pkt = &Pubrel{Header: h}
-	//case pkts.SUBSCRIBE:
-	//	pkt = &Subscribe{Header: h}
+	case pkts.SUBSCRIBE:
+		pkt = &Subscribe{Header: h}
 	case pkts.SUBACK:
 		pkt = &Suback{Header: h}
 	//case pkts.UNSUBSCRIBE:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -147,8 +147,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Subscribe{Header: h}
 	case pkts.SUBACK:
 		pkt = &Suback{Header: h}
-	//case pkts.UNSUBSCRIBE:
-	//	pkt = &Unsubscribe{Header: h}
+	case pkts.UNSUBSCRIBE:
+		pkt = &Unsubscribe{Header: h}
 	case pkts.UNSUBACK:
 		pkt = &Unsuback{Header: h}
 	case pkts.PINGREQ:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -149,8 +149,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Suback{Header: h}
 	//case pkts.UNSUBSCRIBE:
 	//	pkt = &Unsubscribe{Header: h}
-	//case pkts.UNSUBACK:
-	//	pkt = &Unsuback{Header: h}
+	case pkts.UNSUBACK:
+		pkt = &Unsuback{Header: h}
 	case pkts.PINGREQ:
 		pkt = &Pingreq{Header: h}
 	case pkts.PINGRESP:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -145,8 +145,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 		pkt = &Pubrel{Header: h}
 	//case pkts.SUBSCRIBE:
 	//	pkt = &Subscribe{Header: h}
-	//case pkts.SUBACK:
-	//	pkt = &Suback{Header: h}
+	case pkts.SUBACK:
+		pkt = &Suback{Header: h}
 	//case pkts.UNSUBSCRIBE:
 	//	pkt = &Unsubscribe{Header: h}
 	//case pkts.UNSUBACK:

--- a/packets2/packets2.go
+++ b/packets2/packets2.go
@@ -131,8 +131,8 @@ func NewPacketWithHeader(h pkts.Header) (pkt pkts.Packet, err error) {
 	//	pkt = &WillMsg{Header: h}
 	//case pkts.REGISTER:
 	//	pkt = &Register{Header: h}
-	//case pkts.REGACK:
-	//	pkt = &Regack{Header: h}
+	case pkts.REGACK:
+		pkt = &Regack{Header: h}
 	case pkts.PUBLISH:
 		pkt = &Publish{Header: h}
 	case pkts.PUBACK:

--- a/packets2/regack.go
+++ b/packets2/regack.go
@@ -1,0 +1,70 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const regackVarPartLength uint16 = 6
+
+const ()
+
+type Regack struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	TopicAliasType TopicAliasType
+	// Fields
+	TopicAlias uint16
+	PacketIDProperty
+	ReasonCode ReasonCode
+}
+
+func NewRegack(alias uint16, reasonCode ReasonCode, aliasType TopicAliasType) *Regack {
+	return &Regack{
+		Header:         *pkts.NewHeader(pkts.REGACK, regackVarPartLength),
+		TopicAliasType: aliasType,
+		TopicAlias:     alias,
+		ReasonCode:     reasonCode,
+	}
+}
+
+func (p *Regack) encodeFlags() byte {
+	return byte(p.TopicAliasType) & flagsTopicAliasTypeBits
+}
+
+func (p *Regack) decodeFlags(b byte) {
+	p.TopicAliasType = TopicAliasType(b & flagsTopicAliasTypeBits)
+}
+
+func (p *Regack) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicAlias))
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	_ = buf.WriteByte(byte(p.ReasonCode))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Regack) Unpack(buf []byte) error {
+	if len(buf) != int(regackVarPartLength) {
+		return fmt.Errorf("bad REGACK2 packet length: expected %d, got %d",
+			regackVarPartLength, len(buf))
+	}
+
+	p.decodeFlags(buf[0])
+	p.TopicAlias = binary.BigEndian.Uint16(buf[1:3])
+	p.packetID = binary.BigEndian.Uint16(buf[3:5])
+	p.ReasonCode = ReasonCode(buf[5])
+
+	return nil
+}
+
+func (p Regack) String() string {
+	return fmt.Sprintf("REGACK2(Alias(%s)=%d, ReasonCode=%d, PacketID=%d)",
+		p.TopicAliasType, p.TopicAlias, p.ReasonCode, p.packetID)
+}

--- a/packets2/regack_test.go
+++ b/packets2/regack_test.go
@@ -1,0 +1,77 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestRegackConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	topicAlias := uint16(1234)
+	reasonCode := RC_CONGESTION
+	aliasType := TAT_PREDEFINED
+	pkt := NewRegack(topicAlias, reasonCode, aliasType)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Regack", reflect.TypeOf(pkt).String(), "Type should be Regack")
+	assert.Equal(topicAlias, pkt.TopicAlias, "Bad TopicAlias value")
+	assert.Equal(reasonCode, pkt.ReasonCode, "Bad ReasonCode value")
+	assert.Equal(aliasType, pkt.TopicAliasType, "Bad TopicAliasType value")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+	assert.Equal(uint16(8), pkt.PacketLength(), "Default Length should be 8")
+}
+
+func TestRegackMarshal(t *testing.T) {
+	pkt1 := NewRegack(1234, RC_CONGESTION, TAT_PREDEFINED)
+	pkt1.SetPacketID(2345)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Regack))
+}
+
+func TestRegackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		7,                 // Length
+		byte(pkts.REGACK), // Packet Type
+		0,                 // Flags
+		0, 1,              // Topic Alias
+		0, 2, // Packet ID
+		// Reason Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad REGACK2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		7,                 // Length
+		byte(pkts.REGACK), // Packet Type
+		0,                 // Flags
+		0, 1,              // Topic Alias
+		0, 2, // Packet ID
+		0, // Reason Code
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad REGACK2 packet length")
+	}
+}
+
+func TestRegackStringer(t *testing.T) {
+	pkt := NewRegack(1234, RC_CONGESTION, TAT_PREDEFINED)
+	pkt.SetPacketID(2345)
+	assert.Equal(t, "REGACK2(Alias(predefined)=1234, ReasonCode=1, PacketID=2345)", pkt.String())
+}

--- a/packets2/register.go
+++ b/packets2/register.go
@@ -1,0 +1,64 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const registerHeaderLength uint16 = 4
+
+type Register struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	TopicAlias uint16
+	PacketIDProperty
+	TopicName string
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewRegister(alias uint16, topic string) *Register {
+	p := &Register{
+		Header:     *pkts.NewHeader(pkts.REGISTER, 0),
+		TopicAlias: alias,
+		TopicName:  topic,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Register) computeLength() {
+	topicLength := uint16(len(p.TopicName))
+	p.Header.SetVarPartLength(registerHeaderLength + topicLength)
+}
+
+func (p *Register) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicAlias))
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	_, _ = buf.Write([]byte(p.TopicName))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Register) Unpack(buf []byte) error {
+	if len(buf) <= int(registerHeaderLength) {
+		return fmt.Errorf("bad REGISTER2 packet length: expected >%d, got %d",
+			registerHeaderLength, len(buf))
+	}
+
+	p.TopicAlias = binary.BigEndian.Uint16(buf[0:2])
+	p.packetID = binary.BigEndian.Uint16(buf[2:4])
+	p.TopicName = string(buf[4:])
+
+	return nil
+}
+
+func (p Register) String() string {
+	return fmt.Sprintf("REGISTER2(Topic=%q, Alias=%d, PacketID=%d)", string(p.TopicName),
+		p.TopicAlias, p.packetID)
+}

--- a/packets2/register_test.go
+++ b/packets2/register_test.go
@@ -1,0 +1,59 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestRegisterConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	topicAlias := uint16(123)
+	topic := "test-topic"
+	pkt := NewRegister(topicAlias, topic)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Register", reflect.TypeOf(pkt).String(), "Type should be Register")
+	assert.Equal(topicAlias, pkt.TopicAlias, "Bad TopicAlias value")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+	assert.Equal(topic, pkt.TopicName, "Bad TopicName value")
+}
+
+func TestRegisterMarshal(t *testing.T) {
+	pkt1 := NewRegister(1234, "test-topic")
+	pkt1.SetPacketID(2345)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Register))
+}
+
+func TestRegisterUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		6,                   // Length
+		byte(pkts.REGISTER), // Packet Type
+		0, 1,                // Topic Alias
+		0, 2, // Packet ID
+		// TopicName missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad REGISTER2 packet length")
+	}
+}
+
+func TestRegisterStringer(t *testing.T) {
+	pkt := NewRegister(1234, "test-topic")
+	pkt.SetPacketID(2345)
+	assert.Equal(t, `REGISTER2(Topic="test-topic", Alias=1234, PacketID=2345)`,
+		pkt.String())
+}

--- a/packets2/suback.go
+++ b/packets2/suback.go
@@ -1,0 +1,77 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const subackVarPartLength uint16 = 6
+
+type Suback struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	GrantedQOS     uint8
+	TopicAliasType TopicAliasType
+	// Fields
+	TopicAlias uint16
+	PacketIDProperty
+	ReasonCode ReasonCode
+}
+
+func NewSuback(alias uint16, reasonCode ReasonCode, grantedQOS uint8, aliasType TopicAliasType) *Suback {
+	return &Suback{
+		Header:         *pkts.NewHeader(pkts.SUBACK, subackVarPartLength),
+		GrantedQOS:     grantedQOS,
+		TopicAliasType: aliasType,
+		TopicAlias:     alias,
+		ReasonCode:     reasonCode,
+	}
+}
+
+func (p *Suback) encodeFlags() byte {
+	var b byte
+
+	b |= (p.GrantedQOS << 5) & flagsQOSBits
+	b |= uint8(p.TopicAliasType) & flagsTopicAliasTypeBits
+
+	return b
+}
+
+func (p *Suback) decodeFlags(b byte) {
+	p.GrantedQOS = (b & flagsQOSBits) >> 5
+	p.TopicAliasType = TopicAliasType(b & flagsTopicAliasTypeBits)
+}
+
+func (p *Suback) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.TopicAlias))
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	_ = buf.WriteByte(byte(p.ReasonCode))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Suback) Unpack(buf []byte) error {
+	if len(buf) != int(subackVarPartLength) {
+		return fmt.Errorf("bad SUBACK2 packet length: expected %d, got %d",
+			subackVarPartLength, len(buf))
+	}
+
+	p.decodeFlags(buf[0])
+
+	p.TopicAlias = binary.BigEndian.Uint16(buf[1:3])
+	p.packetID = binary.BigEndian.Uint16(buf[3:5])
+	p.ReasonCode = ReasonCode(buf[5])
+
+	return nil
+}
+
+func (p Suback) String() string {
+	return fmt.Sprintf("SUBACK2(Alias(%s)=%d, ReasonCode=%d, QOS=%d, PacketID=%d)",
+		p.TopicAliasType, p.TopicAlias, p.ReasonCode, p.GrantedQOS, p.packetID)
+}

--- a/packets2/suback_test.go
+++ b/packets2/suback_test.go
@@ -1,0 +1,79 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestSubackConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	topicAlias := uint16(12)
+	reasonCode := RC_CONGESTION
+	grantedQOS := uint8(1)
+	aliasType := TAT_PREDEFINED
+	pkt := NewSuback(topicAlias, reasonCode, grantedQOS, aliasType)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Suback", reflect.TypeOf(pkt).String(), "Type should be Suback")
+	assert.Equal(reasonCode, pkt.ReasonCode, "Bad ReasonCode value")
+	assert.Equal(grantedQOS, pkt.GrantedQOS, "Bad GrantedQOS value")
+	assert.Equal(topicAlias, pkt.TopicAlias, "Bad TopicAlias value")
+	assert.Equal(aliasType, pkt.TopicAliasType, "Bad TopicAliasType value")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+	assert.Equal(uint16(8), pkt.PacketLength(), "Default Length should be 8")
+}
+
+func TestSubackMarshal(t *testing.T) {
+	pkt1 := NewSuback(1234, RC_CONGESTION, 1, TAT_PREDEFINED)
+	pkt1.SetPacketID(2345)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Suback))
+}
+
+func TestSubackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		7,                 // Length
+		byte(pkts.SUBACK), // Packet Type
+		0,                 // Flags
+		0, 1,              // Topic Alias
+		0, 2, // Packet ID
+		// Reason Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBACK2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		9,                 // Length
+		byte(pkts.SUBACK), // Packet Type
+		0,                 // Flags
+		0, 1,              // Topic Alias
+		0, 2, // Packet ID
+		0, // Reason Code
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBACK2 packet length")
+	}
+}
+
+func TestSubackStringer(t *testing.T) {
+	pkt := NewSuback(1234, RC_CONGESTION, 1, TAT_PREDEFINED)
+	pkt.SetPacketID(2345)
+	assert.Equal(t, "SUBACK2(Alias(predefined)=1234, ReasonCode=1, QOS=1, PacketID=2345)", pkt.String())
+}

--- a/packets2/subscribe.go
+++ b/packets2/subscribe.go
@@ -1,0 +1,171 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const subscribeHeaderLength uint16 = 3
+
+type Subscribe struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	NoLocal           bool
+	QOS               uint8
+	RetainAsPublished bool
+	RetainHandling    RetainHandling
+	TopicAliasType    TopicAliasType
+	// Fields
+	PacketIDProperty
+	TopicAlias  uint16
+	TopicFilter string
+}
+
+// Retain handling constants.
+type RetainHandling uint8
+
+const (
+	RH_SEND_AT_SUBSCRIBE RetainHandling = iota
+	RH_SEND_AT_NEW_SUBSCRIBE
+	RH_DONT_SEND
+)
+
+func (rh RetainHandling) String() string {
+	switch rh {
+	case RH_SEND_AT_SUBSCRIBE:
+		return "send_at_subscribe"
+	case RH_SEND_AT_NEW_SUBSCRIBE:
+		return "send_at_new_subscribe"
+	case RH_DONT_SEND:
+		return "dont_send"
+	default:
+		return fmt.Sprintf("illegal(%d)", rh)
+	}
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewSubscribe(topicAlias uint16, topicFilter string, noLocal bool, qos uint8,
+	retainedAsPublished bool, retainHandling RetainHandling,
+	topicAliasType TopicAliasType) *Subscribe {
+	p := &Subscribe{
+		Header:            *pkts.NewHeader(pkts.SUBSCRIBE, 0),
+		NoLocal:           noLocal,
+		QOS:               qos,
+		RetainAsPublished: retainedAsPublished,
+		RetainHandling:    retainHandling,
+		TopicAliasType:    topicAliasType,
+		TopicAlias:        topicAlias,
+		TopicFilter:       topicFilter,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Subscribe) computeLength() {
+	var topicLength uint16
+	switch p.TopicAliasType {
+	case TAT_NORMAL, TAT_PREDEFINED, TAT_SHORT:
+		topicLength = 2
+	case TAT_LONG:
+		topicLength = uint16(len(p.TopicFilter))
+	default:
+		panic(fmt.Sprintf("invalid TopicAliasType value: %d", p.TopicAliasType))
+	}
+	p.Header.SetVarPartLength(subscribeHeaderLength + topicLength)
+}
+
+func (p *Subscribe) encodeFlags() byte {
+	var b byte
+
+	if p.NoLocal {
+		b |= flagsNoLocalBit
+	}
+	b |= (p.QOS << 5) & flagsQOSBits
+	if p.RetainAsPublished {
+		b |= flagsRetainAsPublishedBit
+	}
+	b |= (uint8(p.RetainHandling) << 2) & flagsRetainHandlingBits
+	b |= uint8(p.TopicAliasType) & flagsTopicAliasTypeBits
+
+	return b
+}
+
+func (p *Subscribe) decodeFlags(b byte) {
+	p.NoLocal = (b & flagsNoLocalBit) != 0
+	p.QOS = (b & flagsQOSBits) >> 5
+	p.RetainAsPublished = (b & flagsRetainAsPublishedBit) != 0
+	p.RetainHandling = RetainHandling((b & flagsRetainHandlingBits) >> 2)
+	p.TopicAliasType = TopicAliasType(b & flagsTopicAliasTypeBits)
+}
+
+func (p *Subscribe) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	switch p.TopicAliasType {
+	case TAT_NORMAL, TAT_PREDEFINED, TAT_SHORT:
+		_, _ = buf.Write(pkts.EncodeUint16(p.TopicAlias))
+	case TAT_LONG:
+		_, _ = buf.Write([]byte(p.TopicFilter))
+	default:
+		// Should never be reached because TAT is already checked in computeLength().
+		panic(fmt.Sprintf("invalid TopicAliasType value: %d", p.TopicAliasType))
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (p *Subscribe) Unpack(buf []byte) error {
+	if len(buf) <= int(subscribeHeaderLength) {
+		return fmt.Errorf("bad SUBSCRIBE2 packet length: expected >%d, got %d",
+			subscribeHeaderLength, len(buf))
+	}
+
+	p.decodeFlags(buf[0])
+	p.packetID = binary.BigEndian.Uint16(buf[1:3])
+
+	switch p.TopicAliasType {
+	case TAT_NORMAL, TAT_PREDEFINED, TAT_SHORT:
+		if len(buf) != int(subscribeHeaderLength+2) {
+			return fmt.Errorf("bad SUBSCRIBE2 packet length: expected %d, got %d",
+				subscribeHeaderLength+2, len(buf))
+		}
+		p.TopicFilter = ""
+		p.TopicAlias = binary.BigEndian.Uint16(buf[subscribeHeaderLength:])
+	case TAT_LONG:
+		p.TopicFilter = string(buf[subscribeHeaderLength:])
+		p.TopicAlias = 0
+	default:
+		// Should never be reached because TAT is only 2 bits long.
+		panic(fmt.Sprintf("invalid TopicAliasType value: %d", p.TopicAliasType))
+	}
+
+	return nil
+}
+
+func (p Subscribe) String() string {
+	var topicStr string
+	switch p.TopicAliasType {
+	case TAT_NORMAL:
+		fallthrough
+	case TAT_PREDEFINED:
+		topicStr = fmt.Sprintf("TopicAlias(%s)=%d",
+			p.TopicAliasType, p.TopicAlias)
+	case TAT_SHORT:
+		topicStr = fmt.Sprintf("Topic(%s)=%q",
+			p.TopicAliasType, pkts.DecodeShortTopic(p.TopicAlias))
+	case TAT_LONG:
+		topicStr = fmt.Sprintf("Topic(%s)=%q",
+			p.TopicAliasType, p.TopicFilter)
+	default:
+		topicStr = fmt.Sprintf("Topic=%q, TopicAlias=%d, TopicAliasType=%s",
+			p.TopicFilter, p.TopicAlias, p.TopicAliasType)
+	}
+	return fmt.Sprintf("SUBSCRIBE2(%s, QOS=%d, PacketID=%d, NoLocal=%t, RAP=%t, RH=%s)",
+		topicStr, p.QOS, p.packetID, p.NoLocal, p.RetainAsPublished, p.RetainHandling)
+}

--- a/packets2/subscribe_test.go
+++ b/packets2/subscribe_test.go
@@ -1,0 +1,238 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestSubscribeConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	topicAlias := uint16(12)
+	topicFilter := "test-topic"
+	noLocal := true
+	qos := uint8(1)
+	retainAsPublished := true
+	retainHandling := RH_SEND_AT_NEW_SUBSCRIBE
+	aliasType := TAT_PREDEFINED
+	pkt := NewSubscribe(topicAlias, topicFilter, noLocal, qos,
+		retainAsPublished, retainHandling, aliasType)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Subscribe", reflect.TypeOf(pkt).String(), "Type should be Subscribe")
+	assert.Equal(topicAlias, pkt.TopicAlias, "Bad TopicAlias value")
+	assert.Equal(topicFilter, pkt.TopicFilter, "Bad TopicFilter value")
+	assert.Equal(noLocal, pkt.NoLocal, "Bad NoLocal value")
+	assert.Equal(qos, pkt.QOS, "Bad QOS value")
+	assert.Equal(retainAsPublished, pkt.RetainAsPublished, "Bad RetainAsPublished value")
+	assert.Equal(retainHandling, pkt.RetainHandling, "Bad RetainHandling value")
+	assert.Equal(aliasType, pkt.TopicAliasType, "Bad TopicAliasType value")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestSubscribeMarshal(t *testing.T) {
+	// Normal topic alias.
+	pkt1 := NewSubscribe(1234, "", true, 1, true, RH_SEND_AT_NEW_SUBSCRIBE,
+		TAT_NORMAL)
+	pkt1.SetPacketID(2345)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Subscribe))
+
+	// Predefined topic alias.
+	pkt1 = NewSubscribe(1234, "", true, 1, true, RH_SEND_AT_NEW_SUBSCRIBE,
+		TAT_PREDEFINED)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Subscribe))
+
+	// Short topic.
+	pkt1 = NewSubscribe(pkts.EncodeShortTopic("ab"), "", true, 1, true,
+		RH_SEND_AT_NEW_SUBSCRIBE, TAT_SHORT)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Subscribe))
+
+	// Long topic.
+	pkt1 = NewSubscribe(0, "test-topic", true, 1, true,
+		RH_SEND_AT_NEW_SUBSCRIBE, TAT_LONG)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Subscribe))
+}
+
+func TestSubscribeUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short - normal Topic Alias.
+	buff := bytes.NewBuffer([]byte{
+		6,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_NORMAL),     // Flags
+		0, 1,                 // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - predefined Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		6,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_PREDEFINED), // Flags
+		0, 1,                 // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - short Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		6,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_SHORT),      // Flags
+		0, 1,                 // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - long Topic.
+	buff = bytes.NewBuffer([]byte{
+		5,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_LONG),       // Flags
+		0, 1,                 // Packet ID
+		// Missing Topic Filter
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+
+	// Packet too long - normal Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_NORMAL),     // Flags
+		0, 1,                 // Packet ID
+		0, 2, // Topic Alias
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+
+	// Packet long short - predefined Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_PREDEFINED), // Flags
+		0, 1,                 // Packet ID
+		0, 2, // Topic Alias
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - short Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                    // Length
+		byte(pkts.SUBSCRIBE), // Packet Type
+		byte(TAT_SHORT),      // Flags
+		0, 1,                 // Packet ID
+		0, 2, // Topic Alias
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad SUBSCRIBE2 packet length")
+	}
+}
+
+func TestSubscribeStringer(t *testing.T) {
+	assert := assert.New(t)
+
+	// Normal topic alias.
+	pkt := NewSubscribe(1234, "", true, 1, true, RH_SEND_AT_NEW_SUBSCRIBE,
+		TAT_NORMAL)
+	pkt.SetPacketID(2345)
+	assert.Equal(`SUBSCRIBE2(TopicAlias(normal)=1234, QOS=1, PacketID=2345, NoLocal=true, RAP=true, RH=send_at_new_subscribe)`,
+		pkt.String())
+
+	// Predefined topic alias.
+	pkt = NewSubscribe(1234, "", true, 1, true, RH_SEND_AT_NEW_SUBSCRIBE,
+		TAT_PREDEFINED)
+	pkt.SetPacketID(2345)
+	assert.Equal(`SUBSCRIBE2(TopicAlias(predefined)=1234, QOS=1, PacketID=2345, NoLocal=true, RAP=true, RH=send_at_new_subscribe)`,
+		pkt.String())
+
+	// Short topic.
+	pkt = NewSubscribe(pkts.EncodeShortTopic("ab"), "", true, 1, true,
+		RH_SEND_AT_NEW_SUBSCRIBE, TAT_SHORT)
+	pkt.SetPacketID(2345)
+	assert.Equal(`SUBSCRIBE2(Topic(short)="ab", QOS=1, PacketID=2345, NoLocal=true, RAP=true, RH=send_at_new_subscribe)`,
+		pkt.String())
+
+	// Long topic.
+	pkt = NewSubscribe(0, "test-topic", true, 1, true,
+		RH_SEND_AT_NEW_SUBSCRIBE, TAT_LONG)
+	pkt.SetPacketID(2345)
+	assert.Equal(`SUBSCRIBE2(Topic(long)="test-topic", QOS=1, PacketID=2345, NoLocal=true, RAP=true, RH=send_at_new_subscribe)`,
+		pkt.String())
+
+	// Illegal topic alias type.
+	pkt = NewSubscribe(1234, "test-topic", true, 1, true,
+		RH_SEND_AT_NEW_SUBSCRIBE, TAT_LONG)
+	pkt.TopicAliasType = 5
+	pkt.SetPacketID(2345)
+	assert.Equal(`SUBSCRIBE2(Topic="test-topic", TopicAlias=1234, TopicAliasType=illegal(5), QOS=1, PacketID=2345, NoLocal=true, RAP=true, RH=send_at_new_subscribe)`,
+		pkt.String())
+}
+
+func TestSubscribeInvalidAliasType(t *testing.T) {
+	assert := assert.New(t)
+
+	// Topic Alias Type checked in constructor.
+	assert.PanicsWithValue("invalid TopicAliasType value: 5", func() {
+		NewSubscribe(1234, "test-topic", true, 1, true, RH_SEND_AT_NEW_SUBSCRIBE,
+			5, // Illegal Topic Alias Type value
+		)
+	})
+
+	// Topic Alias Type checked in Pack().
+	assert.PanicsWithValue("invalid TopicAliasType value: 5", func() {
+		pkt := NewSubscribe(1234, "test-topic", true, 1, true, RH_SEND_AT_NEW_SUBSCRIBE,
+			TAT_NORMAL)
+		pkt.TopicAliasType = 5
+		pkt.Pack()
+	})
+}
+
+func TestRetainHandlingStringer(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("send_at_subscribe", RH_SEND_AT_SUBSCRIBE.String())
+	assert.Equal("send_at_new_subscribe", RH_SEND_AT_NEW_SUBSCRIBE.String())
+	assert.Equal("dont_send", RH_DONT_SEND.String())
+	assert.Equal("illegal(123)", RetainHandling(123).String())
+}

--- a/packets2/unsuback.go
+++ b/packets2/unsuback.go
@@ -1,0 +1,50 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const unsubackVarPartLength uint16 = 3
+
+type Unsuback struct {
+	pkts.Header
+	PacketV2
+	// Fields
+	PacketIDProperty
+	ReasonCode ReasonCode
+}
+
+func NewUnsuback(reasonCode ReasonCode) *Unsuback {
+	return &Unsuback{
+		Header:     *pkts.NewHeader(pkts.UNSUBACK, unsubackVarPartLength),
+		ReasonCode: reasonCode,
+	}
+}
+
+func (p *Unsuback) Pack() ([]byte, error) {
+	buf := p.Header.PackToBuffer()
+
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	_ = buf.WriteByte(uint8(p.ReasonCode))
+
+	return buf.Bytes(), nil
+}
+
+func (p *Unsuback) Unpack(buf []byte) error {
+	if len(buf) != int(unsubackVarPartLength) {
+		return fmt.Errorf("bad UNSUBACK2 packet length: expected %d, got %d",
+			unsubackVarPartLength, len(buf))
+	}
+
+	p.packetID = binary.BigEndian.Uint16(buf[0:2])
+	p.ReasonCode = ReasonCode(buf[2])
+
+	return nil
+}
+
+func (p Unsuback) String() string {
+	return fmt.Sprintf("UNSUBACK2(ReasonCode=%s, PacketID=%d)", p.ReasonCode, p.packetID)
+}

--- a/packets2/unsuback_test.go
+++ b/packets2/unsuback_test.go
@@ -1,0 +1,68 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestUnsubackConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	pkt := NewUnsuback(RC_CONGESTION)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Unsuback", reflect.TypeOf(pkt).String(), "Type should be Unsuback")
+	assert.Equal(RC_CONGESTION, pkt.ReasonCode, "Bad ReasonCode value")
+	assert.Equal(uint16(5), pkt.PacketLength(), "Default Length should be 5")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestUnsubackMarshal(t *testing.T) {
+	pkt1 := NewUnsuback(RC_CONGESTION)
+	pkt1.SetPacketID(1234)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsuback))
+}
+
+func TestUnsubackUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short.
+	buff := bytes.NewBuffer([]byte{
+		4,                   // Length
+		byte(pkts.UNSUBACK), // Packet Type
+		0, 1,                // Packet ID
+		// Reason Code missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBACK2 packet length")
+	}
+
+	// Packet too long.
+	buff = bytes.NewBuffer([]byte{
+		5,                   // Length
+		byte(pkts.UNSUBACK), // Packet Type
+		0, 1,                // Packet ID
+		0, 2, // Reason Code
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBACK2 packet length")
+	}
+}
+
+func TestUnsubackStringer(t *testing.T) {
+	pkt := NewUnsuback(RC_CONGESTION)
+	pkt.SetPacketID(1234)
+	assert.Equal(t, "UNSUBACK2(ReasonCode=congestion, PacketID=1234)", pkt.String())
+}

--- a/packets2/unsubscribe.go
+++ b/packets2/unsubscribe.go
@@ -1,0 +1,124 @@
+package packets2
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+const unsubscribeHeaderLength uint16 = 3
+
+type Unsubscribe struct {
+	pkts.Header
+	PacketV2
+	// Flags
+	TopicAliasType TopicAliasType
+	// Fields
+	PacketIDProperty
+	TopicAlias  uint16
+	TopicFilter string
+}
+
+// NOTE: Packet length is initialized in this constructor and recomputed in m.Write().
+func NewUnsubscribe(topicAlias uint16, topicFilter string, topicAliasType TopicAliasType) *Unsubscribe {
+	p := &Unsubscribe{
+		Header:         *pkts.NewHeader(pkts.UNSUBSCRIBE, 0),
+		TopicAliasType: topicAliasType,
+		TopicAlias:     topicAlias,
+		TopicFilter:    topicFilter,
+	}
+	p.computeLength()
+	return p
+}
+
+func (p *Unsubscribe) computeLength() {
+	var topicLength uint16
+	switch p.TopicAliasType {
+	case TAT_NORMAL, TAT_PREDEFINED, TAT_SHORT:
+		topicLength = 2
+	case TAT_LONG:
+		topicLength = uint16(len(p.TopicFilter))
+	default:
+		panic(fmt.Sprintf("invalid TopicAliasType value: %d", p.TopicAliasType))
+	}
+	p.Header.SetVarPartLength(unsubscribeHeaderLength + topicLength)
+}
+
+func (p *Unsubscribe) encodeFlags() byte {
+	var b byte
+	b |= uint8(p.TopicAliasType) & flagsTopicAliasTypeBits
+	return b
+}
+
+func (p *Unsubscribe) decodeFlags(b byte) {
+	p.TopicAliasType = TopicAliasType(b & flagsTopicAliasTypeBits)
+}
+
+func (p *Unsubscribe) Pack() ([]byte, error) {
+	p.computeLength()
+	buf := p.Header.PackToBuffer()
+
+	_ = buf.WriteByte(p.encodeFlags())
+	_, _ = buf.Write(pkts.EncodeUint16(p.packetID))
+	switch p.TopicAliasType {
+	case TAT_NORMAL, TAT_PREDEFINED, TAT_SHORT:
+		_, _ = buf.Write(pkts.EncodeUint16(p.TopicAlias))
+	case TAT_LONG:
+		_, _ = buf.Write([]byte(p.TopicFilter))
+	default:
+		// Should never be reached because TAT is already checked in computeLength().
+		panic(fmt.Sprintf("invalid TopicAliasType value: %d", p.TopicAliasType))
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (p *Unsubscribe) Unpack(buf []byte) error {
+	if len(buf) <= int(unsubscribeHeaderLength) {
+		return fmt.Errorf("bad UNSUBSCRIBE2 packet length: expected >%d, got %d",
+			unsubscribeHeaderLength, len(buf))
+	}
+
+	p.decodeFlags(buf[0])
+	p.packetID = binary.BigEndian.Uint16(buf[1:3])
+
+	switch p.TopicAliasType {
+	case TAT_NORMAL, TAT_PREDEFINED, TAT_SHORT:
+		if len(buf) != int(unsubscribeHeaderLength+2) {
+			return fmt.Errorf("bad UNSUBSCRIBE2 packet length: expected %d, got %d",
+				unsubscribeHeaderLength+2, len(buf))
+		}
+		p.TopicFilter = ""
+		p.TopicAlias = binary.BigEndian.Uint16(buf[subscribeHeaderLength:])
+	case TAT_LONG:
+		p.TopicAlias = 0
+		p.TopicFilter = string(buf[subscribeHeaderLength:])
+	default:
+		// Should never be reached because TAT is only 2 bits long.
+		panic(fmt.Sprintf("invalid TopicAliasType value: %d", p.TopicAliasType))
+	}
+
+	return nil
+}
+
+func (p Unsubscribe) String() string {
+	var topicStr string
+	switch p.TopicAliasType {
+	case TAT_NORMAL:
+		fallthrough
+	case TAT_PREDEFINED:
+		topicStr = fmt.Sprintf("TopicAlias(%s)=%d",
+			p.TopicAliasType, p.TopicAlias)
+	case TAT_SHORT:
+		topicStr = fmt.Sprintf("Topic(%s)=%q",
+			p.TopicAliasType, pkts.DecodeShortTopic(p.TopicAlias))
+	case TAT_LONG:
+		topicStr = fmt.Sprintf("Topic(%s)=%q",
+			p.TopicAliasType, p.TopicFilter)
+	default:
+		topicStr = fmt.Sprintf("Topic=%q, TopicAlias=%d, TopicAliasType=%s",
+			p.TopicFilter, p.TopicAlias, p.TopicAliasType)
+	}
+	return fmt.Sprintf("UNSUBSCRIBE2(%s, PacketID=%d)", topicStr, p.packetID)
+}

--- a/packets2/unsubscribe_test.go
+++ b/packets2/unsubscribe_test.go
@@ -1,0 +1,208 @@
+package packets2
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkts "github.com/energomonitor/bisquitt/packets"
+)
+
+func TestUnsubscribeConstructor(t *testing.T) {
+	assert := assert.New(t)
+
+	topicAlias := uint16(12)
+	topicFilter := "test-topic"
+	aliasType := TAT_PREDEFINED
+	pkt := NewUnsubscribe(topicAlias, topicFilter, aliasType)
+
+	if pkt == nil {
+		t.Fatal("New packet should not be nil")
+	}
+
+	assert.Equal("*packets2.Unsubscribe", reflect.TypeOf(pkt).String(), "Type should be Unsubscribe")
+	assert.Equal(topicAlias, pkt.TopicAlias, "Bad TopicAlias value")
+	assert.Equal(topicFilter, pkt.TopicFilter, "Bad TopicFilter value")
+	assert.Equal(aliasType, pkt.TopicAliasType, "Bad TopicAliasType value")
+	assert.Equal(uint16(0), pkt.PacketID(), "Default PacketID should be 0")
+}
+
+func TestUnsubscribeMarshal(t *testing.T) {
+	// Normal topic alias.
+	pkt1 := NewUnsubscribe(1234, "", TAT_NORMAL)
+	pkt1.SetPacketID(2345)
+	pkt2 := testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
+
+	// Predefined topic alias.
+	pkt1 = NewUnsubscribe(1234, "", TAT_PREDEFINED)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
+
+	// Short topic.
+	pkt1 = NewUnsubscribe(pkts.EncodeShortTopic("ab"), "", TAT_SHORT)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
+
+	// Long topic.
+	pkt1 = NewUnsubscribe(0, "test-topic", TAT_LONG)
+	pkt1.SetPacketID(2345)
+	pkt2 = testPacketMarshal(t, pkt1)
+	assert.Equal(t, pkt1, pkt2.(*Unsubscribe))
+}
+
+func TestUnsubscribeUnmarshalInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	// Packet too short - normal Topic Alias.
+	buff := bytes.NewBuffer([]byte{
+		6,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_NORMAL),       // Flags
+		0, 1,                   // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err := ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - predefined Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		6,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_PREDEFINED),   // Flags
+		0, 1,                   // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - short Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		6,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_SHORT),        // Flags
+		0, 1,                   // Packet ID
+		0, // Topic Alias MSB
+		// Topic Alias LSB missing
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - long Topic.
+	buff = bytes.NewBuffer([]byte{
+		5,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_LONG),         // Flags
+		0, 1,                   // Packet ID
+		// Missing Topic Filter
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+
+	// Packet too long - normal Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_NORMAL),       // Flags
+		0, 1,                   // Packet ID
+		0, 2, // Topic Alias
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+
+	// Packet long short - predefined Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_PREDEFINED),   // Flags
+		0, 1,                   // Packet ID
+		0, 2, // Topic Alias
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+
+	// Packet too short - short Topic Alias.
+	buff = bytes.NewBuffer([]byte{
+		8,                      // Length
+		byte(pkts.UNSUBSCRIBE), // Packet Type
+		byte(TAT_SHORT),        // Flags
+		0, 1,                   // Packet ID
+		0, 2, // Topic Alias
+		0, // junk
+	})
+	_, err = ReadPacket(buff)
+	if assert.Error(err) {
+		assert.Contains(err.Error(), "bad UNSUBSCRIBE2 packet length")
+	}
+}
+
+func TestUnsubscribeStringer(t *testing.T) {
+	assert := assert.New(t)
+
+	// Normal topic alias.
+	pkt := NewUnsubscribe(1234, "", TAT_NORMAL)
+	pkt.SetPacketID(2345)
+	assert.Equal(`UNSUBSCRIBE2(TopicAlias(normal)=1234, PacketID=2345)`,
+		pkt.String())
+
+	// Predefined topic alias.
+	pkt = NewUnsubscribe(1234, "", TAT_PREDEFINED)
+	pkt.SetPacketID(2345)
+	assert.Equal(`UNSUBSCRIBE2(TopicAlias(predefined)=1234, PacketID=2345)`,
+		pkt.String())
+
+	// Short topic.
+	pkt = NewUnsubscribe(pkts.EncodeShortTopic("ab"), "", TAT_SHORT)
+	pkt.SetPacketID(2345)
+	assert.Equal(`UNSUBSCRIBE2(Topic(short)="ab", PacketID=2345)`,
+		pkt.String())
+
+	// Long topic.
+	pkt = NewUnsubscribe(0, "test-topic", TAT_LONG)
+	pkt.SetPacketID(2345)
+	assert.Equal(`UNSUBSCRIBE2(Topic(long)="test-topic", PacketID=2345)`,
+		pkt.String())
+
+	// Illegal topic alias type.
+	pkt = NewUnsubscribe(1234, "test-topic", TAT_LONG)
+	pkt.TopicAliasType = 5
+	pkt.SetPacketID(2345)
+	assert.Equal(`UNSUBSCRIBE2(Topic="test-topic", TopicAlias=1234, TopicAliasType=illegal(5), PacketID=2345)`,
+		pkt.String())
+}
+
+func TestUnsubscribeInvalidAliasType(t *testing.T) {
+	assert := assert.New(t)
+
+	// Topic Alias Type checked in constructor.
+	assert.PanicsWithValue("invalid TopicAliasType value: 5", func() {
+		NewUnsubscribe(1234, "test-topic", 5)
+	})
+
+	// Topic Alias Type checked in Pack().
+	assert.PanicsWithValue("invalid TopicAliasType value: 5", func() {
+		pkt := NewUnsubscribe(1234, "test-topic", TAT_NORMAL)
+		pkt.TopicAliasType = 5
+		pkt.Pack()
+	})
+}


### PR DESCRIPTION
PR adds register and subscribe-related packets: `Register`, `Regack`, `Subscribe`, `Suback`, `Unsubscribe`, `Unsuback`.

Failed tests are OK. They will pass as long as all packets are merged in.