### PR TITLE
Make `packets1.NewPacketWithHeader()` return `error`

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1890,11 +1890,18 @@ func (stp *testSetup) recv() pkts.Packet {
 	rawPacket = rawPacket[:n]
 
 	var h pkts.Header
-	h.Unpack(rawPacket)
-	p := pkts1.NewPacketWithHeader(h)
-	p.Unpack(rawPacket[h.HeaderLength():])
+	if err := h.Unpack(rawPacket); err != nil {
+		stp.t.Fatal(err)
+	}
+	pkt, err := pkts1.NewPacketWithHeader(h)
+	if err != nil {
+		stp.t.Fatal(err)
+	}
+	if err := pkt.Unpack(rawPacket[h.HeaderLength():]); err != nil {
+		stp.t.Fatal(err)
+	}
 
-	return p
+	return pkt
 }
 
 func testRead(conn net.Conn, timeout time.Duration) ([]byte, error) {

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1341,11 +1341,18 @@ func (stp *testSetup) snRecv() snPkts.Packet {
 	rawPacket = rawPacket[:n]
 
 	var h snPkts.Header
-	h.Unpack(rawPacket)
-	p := snPkts1.NewPacketWithHeader(h)
-	p.Unpack(rawPacket[h.HeaderLength():])
+	if err := h.Unpack(rawPacket); err != nil {
+		stp.t.Fatal(err)
+	}
+	pkt, err := snPkts1.NewPacketWithHeader(h)
+	if err != nil {
+		stp.t.Fatal(err)
+	}
+	if err := pkt.Unpack(rawPacket[h.HeaderLength():]); err != nil {
+		stp.t.Fatal(err)
+	}
 
-	return p
+	return pkt
 }
 
 func (stp *testSetup) mqttSend(pkt mqPkts.ControlPacket, setMsgID bool) {

--- a/packets1/packets1_test.go
+++ b/packets1/packets1_test.go
@@ -42,6 +42,6 @@ func TestUnmarshalInvalidPacketType(t *testing.T) {
 	})
 	_, err := ReadPacket(buff)
 	if assert.Error(t, err) {
-		assert.Equal(t, err.Error(), "invalid MQTT-SN packet type")
+		assert.Equal(t, err.Error(), "invalid MQTT-SN 1.2 packet type: 25")
 	}
 }


### PR DESCRIPTION
Returning explicit error is better than returning nil.

Commit also renames `packet` variable to `rawPacket` to be more explicit and consistent with MQTT-SN 2.x code.