### PR TITLE
packets1: Fix field name in `WillTopicUpd.String`

### DIFF
--- a/packets1/willtopicupd.go
+++ b/packets1/willtopicupd.go
@@ -84,7 +84,7 @@ func (p *WillTopicUpd) Unpack(buf []byte) error {
 
 func (p WillTopicUpd) String() string {
 	if len(p.WillTopic) == 0 {
-		return fmt.Sprintf(`WILLTOPICUPD(WillTopicUpd="")`)
+		return fmt.Sprintf(`WILLTOPICUPD(WillTopic="")`)
 	}
-	return fmt.Sprintf("WILLTOPICUPD(WillTopicUpd=%#v, QOS=%d, Retain=%t)", p.WillTopic, p.QOS, p.Retain)
+	return fmt.Sprintf("WILLTOPICUPD(WillTopic=%#v, QOS=%d, Retain=%t)", p.WillTopic, p.QOS, p.Retain)
 }

--- a/packets1/willtopicupd_test.go
+++ b/packets1/willtopicupd_test.go
@@ -57,9 +57,9 @@ func TestWillTopicUpdUnmarshalInvalid(t *testing.T) {
 
 func TestWillTopicUpdStringer(t *testing.T) {
 	pkt := NewWillTopicUpd("test-topic", 1, true)
-	assert.Equal(t, `WILLTOPICUPD(WillTopicUpd="test-topic", QOS=1, Retain=true)`, pkt.String())
+	assert.Equal(t, `WILLTOPICUPD(WillTopic="test-topic", QOS=1, Retain=true)`, pkt.String())
 
 	// Packet with a zero-length topic.
 	pkt = NewWillTopicUpd("", 0, false)
-	assert.Equal(t, `WILLTOPICUPD(WillTopicUpd="")`, pkt.String())
+	assert.Equal(t, `WILLTOPICUPD(WillTopic="")`, pkt.String())
 }


### PR DESCRIPTION
Field name used in `WillTopicUpd.String` output didn’t match the struct itself.